### PR TITLE
Add dosing safeguards and product label carousels

### DIFF
--- a/acetaminophen.html
+++ b/acetaminophen.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Acetaminophen Guide</title>
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+  <nav class="tabs">
+    <a href="index.html">Calculator</a>
+    <a href="acetaminophen.html" class="active">Acetaminophen Guide</a>
+    <a href="ibuprofen.html">Ibuprofen Guide</a>
+  </nav>
+
+  <main class="page">
+    <section class="panel">
+      <h1>Acetaminophen Guide</h1>
+      <p>
+        Acetaminophen is commonly used for fever and pain relief. Dosing is based on your child's
+        weight. Always double-check the concentration on the medication bottle and use the dosing
+        device that comes with the product.
+      </p>
+      <section class="carousel-section" data-carousel>
+        <h2>Common Infant Products</h2>
+        <div class="carousel-track">
+          <figure class="carousel-slide">
+            <img src="images/acetaminophen-tylenol.svg" alt="Tylenol infant acetaminophen 160 mg per 5 mL oral suspension label" />
+            <figcaption>Tylenol<sup>&reg;</sup> Infant Oral Suspension (160 mg per 5 mL)</figcaption>
+          </figure>
+          <figure class="carousel-slide">
+            <img src="images/acetaminophen-generic.svg" alt="Generic infants acetaminophen 160 mg per 5 mL oral suspension label" />
+            <figcaption>Store Brand Infant Acetaminophen (160 mg per 5 mL)</figcaption>
+          </figure>
+        </div>
+        <div class="carousel-controls">
+          <button type="button" data-carousel-prev aria-label="Show previous acetaminophen product">&#8592;</button>
+          <div class="carousel-dots" aria-hidden="true"></div>
+          <button type="button" data-carousel-next aria-label="Show next acetaminophen product">&#8594;</button>
+        </div>
+      </section>
+      <h2>When to Use</h2>
+      <ul>
+        <li>Fever or discomfort associated with mild illnesses.</li>
+        <li>Pain after immunizations or minor injuries.</li>
+        <li>As directed by your pediatrician for teething discomfort.</li>
+      </ul>
+      <h2>Safety Tips</h2>
+      <ul>
+        <li>Do not exceed 5 doses in 24 hours.</li>
+        <li>Allow at least 4 hours between doses for infants 2-6 months old.</li>
+        <li>Keep a log of the time and dose to avoid accidental repeat dosing.</li>
+        <li>Contact a healthcare provider for children under 2 months of age with a fever.</li>
+      </ul>
+      <p>
+        For quick dosing, return to the <a href="index.html">calculator</a> and enter your child's
+        age and weight.
+      </p>
+    </section>
+  </main>
+
+  <footer>
+    <p><strong>Disclaimer:</strong> Educational use only &mdash; confirm dosing with a licensed healthcare professional before giving medication.</p>
+    <p>Updated 1.13.2025 &bull; Created by Nickolas Mancini, MD, MBA</p>
+  </footer>
+</body>
+</html>

--- a/ibuprofen.html
+++ b/ibuprofen.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Ibuprofen Guide</title>
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+  <nav class="tabs">
+    <a href="index.html">Calculator</a>
+    <a href="acetaminophen.html">Acetaminophen Guide</a>
+    <a href="ibuprofen.html" class="active">Ibuprofen Guide</a>
+  </nav>
+
+  <main class="page">
+    <section class="panel">
+      <h1>Ibuprofen Guide</h1>
+      <p>
+        Ibuprofen helps reduce fever, pain, and inflammation. Use ibuprofen only for children older
+        than 6 months unless directed by a healthcare provider.
+      </p>
+      <section class="carousel-section" data-carousel>
+        <h2>Common Pediatric Products</h2>
+        <div class="carousel-track">
+          <figure class="carousel-slide">
+            <img src="images/ibuprofen-infant.svg" alt="Infant's Motrin ibuprofen 50 mg per 1.25 mL label" />
+            <figcaption>Infant's Motrin<sup>&reg;</sup> Concentrated Drops (50 mg per 1.25 mL)</figcaption>
+          </figure>
+          <figure class="carousel-slide">
+            <img src="images/ibuprofen-children.svg" alt="Children's Advil ibuprofen 100 mg per 5 mL label" />
+            <figcaption>Children's Advil<sup>&reg;</sup> Suspension (100 mg per 5 mL)</figcaption>
+          </figure>
+        </div>
+        <div class="carousel-controls">
+          <button type="button" data-carousel-prev aria-label="Show previous ibuprofen product">&#8592;</button>
+          <div class="carousel-dots" aria-hidden="true"></div>
+          <button type="button" data-carousel-next aria-label="Show next ibuprofen product">&#8594;</button>
+        </div>
+      </section>
+      <h2>Common Uses</h2>
+      <ul>
+        <li>Fever or pain associated with viral illnesses.</li>
+        <li>Pain and swelling from sprains or strains.</li>
+        <li>Discomfort associated with ear infections or sore throat.</li>
+      </ul>
+      <h2>Safety Tips</h2>
+      <ul>
+        <li>Give with food or milk to minimize stomach upset.</li>
+        <li>Avoid use in children who are dehydrated or vomiting frequently.</li>
+        <li>Do not combine with other anti-inflammatory medicines unless advised.</li>
+        <li>Spacing between doses should be at least 6 hours.</li>
+      </ul>
+      <p>
+        Need to double-check a dose? Visit the <a href="index.html">calculator</a> for a personalized
+        recommendation.
+      </p>
+    </section>
+  </main>
+
+  <footer>
+    <p><strong>Disclaimer:</strong> Educational use only &mdash; confirm dosing with a licensed healthcare professional before giving medication.</p>
+    <p>Updated 1.13.2025 &bull; Created by Nickolas Mancini, MD, MBA</p>
+  </footer>
+</body>
+</html>

--- a/images/acetaminophen-generic.svg
+++ b/images/acetaminophen-generic.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 200">
+  <rect width="320" height="200" rx="24" fill="#1e88e5" />
+  <rect x="20" y="20" width="280" height="70" rx="14" fill="#ffffff" opacity="0.25" />
+  <text x="160" y="66" fill="#ffffff" font-family="'Segoe UI', Arial, sans-serif" font-size="30" font-weight="700" text-anchor="middle">Infant Pain &amp; Fever</text>
+  <text x="160" y="110" fill="#bbdefb" font-family="'Segoe UI', Arial, sans-serif" font-size="18" font-weight="600" text-anchor="middle">Acetaminophen Oral Suspension</text>
+  <text x="160" y="142" fill="#ffffff" font-family="'Segoe UI', Arial, sans-serif" font-size="20" font-weight="600" text-anchor="middle">160 mg per 5 mL</text>
+  <text x="160" y="170" fill="#e3f2fd" font-family="'Segoe UI', Arial, sans-serif" font-size="14" text-anchor="middle">Compare to Infants' Tylenol<sup>&reg;</sup></text>
+</svg>

--- a/images/acetaminophen-tylenol.svg
+++ b/images/acetaminophen-tylenol.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 200">
+  <defs>
+    <linearGradient id="bg" x1="0%" x2="100%" y1="0%" y2="100%">
+      <stop offset="0%" stop-color="#c3171f" />
+      <stop offset="100%" stop-color="#800d12" />
+    </linearGradient>
+  </defs>
+  <rect width="320" height="200" rx="24" fill="url(#bg)" />
+  <text x="160" y="70" fill="#ffffff" font-family="'Segoe UI', Arial, sans-serif" font-size="36" font-weight="700" text-anchor="middle">TYLENOL</text>
+  <text x="160" y="105" fill="#ffe082" font-family="'Segoe UI', Arial, sans-serif" font-size="18" font-weight="600" text-anchor="middle">Infants' Oral Suspension</text>
+  <text x="160" y="138" fill="#ffffff" font-family="'Segoe UI', Arial, sans-serif" font-size="20" font-weight="600" text-anchor="middle">160 mg per 5 mL</text>
+  <text x="160" y="168" fill="#ffffff" font-family="'Segoe UI', Arial, sans-serif" font-size="14" text-anchor="middle">Cherry Flavor · Shake Well</text>
+</svg>

--- a/images/ibuprofen-children.svg
+++ b/images/ibuprofen-children.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 200">
+  <rect width="320" height="200" rx="24" fill="#0d47a1" />
+  <rect x="24" y="24" width="272" height="152" rx="20" fill="#1565c0" opacity="0.85" />
+  <text x="160" y="72" fill="#ffffff" font-family="'Segoe UI', Arial, sans-serif" font-size="32" font-weight="700" text-anchor="middle">Children's Advil</text>
+  <text x="160" y="110" fill="#bbdefb" font-family="'Segoe UI', Arial, sans-serif" font-size="18" font-weight="600" text-anchor="middle">Ibuprofen Oral Suspension</text>
+  <text x="160" y="146" fill="#ffffff" font-family="'Segoe UI', Arial, sans-serif" font-size="22" font-weight="600" text-anchor="middle">100 mg per 5 mL</text>
+</svg>

--- a/images/ibuprofen-infant.svg
+++ b/images/ibuprofen-infant.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 200">
+  <defs>
+    <linearGradient id="motrin" x1="0%" x2="100%" y1="0%" y2="100%">
+      <stop offset="0%" stop-color="#ff9800" />
+      <stop offset="100%" stop-color="#ef6c00" />
+    </linearGradient>
+  </defs>
+  <rect width="320" height="200" rx="24" fill="url(#motrin)" />
+  <text x="160" y="64" fill="#ffffff" font-family="'Segoe UI', Arial, sans-serif" font-size="34" font-weight="700" text-anchor="middle">MOTRIN</text>
+  <text x="160" y="96" fill="#ffe0b2" font-family="'Segoe UI', Arial, sans-serif" font-size="18" font-weight="600" text-anchor="middle">Infants' Drops</text>
+  <text x="160" y="132" fill="#ffffff" font-family="'Segoe UI', Arial, sans-serif" font-size="22" font-weight="600" text-anchor="middle">50 mg per 1.25 mL</text>
+  <text x="160" y="162" fill="#ffffff" font-family="'Segoe UI', Arial, sans-serif" font-size="14" text-anchor="middle">Dye-Free · Berry Flavor</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -1,44 +1,93 @@
 <!DOCTYPE html>
-<html lang="en" >
+<html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <title>Calc v1</title>
-  <link rel="stylesheet" href="./style.css">
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Pain &amp; Fever Medication Dose Calculator</title>
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+  <nav class="tabs">
+    <a href="index.html" class="active">Calculator</a>
+    <a href="acetaminophen.html">Acetaminophen Guide</a>
+    <a href="ibuprofen.html">Ibuprofen Guide</a>
+  </nav>
 
-</head>
-<body>
-<!-- partial:index.partial.html -->
-<title>Pain/Fever Medication Dose Calculator v1.1</title>
-    <link rel="stylesheet" href="styles.css"> <!-- Link to CSS -->
-</head>
-<body>
-    <div id="message" style="display: none;"></div>
-    <div id="form">
-        <h1>Pain/Fever Medication Dose Calculator v1.1</h1>
-        <label for="age">Patient Age:</label>
+  <main class="page">
+    <div id="message" role="alert" aria-live="polite" hidden></div>
+
+    <section id="calculator" class="panel" aria-labelledby="calculator-heading">
+      <h1 id="calculator-heading">Pain/Fever Medication Dose Calculator</h1>
+      <div class="field">
+        <label for="age">Patient Age</label>
         <select id="age" onchange="updateForm()">
-            <option value="">Select Age</option>
-            <option value="0-2">0-2 months</option>
-            <option value="2-6">2-6 months</option>
-            <option value="6+">6+ months</option>
+          <option value="">Select Age</option>
+          <option value="0-2">0-2 months</option>
+          <option value="2-6">2-6 months</option>
+          <option value="6+">6+ months</option>
         </select>
-      <br>
-      <label for="weight">Patient Weight:</label>
-        <input type="number" id="weight" placeholder="Enter weight">
-        <select id="weight-unit">
+      </div>
+
+      <div class="field">
+        <label for="weight">Patient Weight</label>
+        <div class="weight-input">
+          <input type="number" id="weight" placeholder="Enter weight" min="0" step="0.1" />
+          <select id="weight-unit">
             <option value="lbs">lbs</option>
             <option value="kg">kg</option>
-        </select>
-        <button onclick="calculateDose()">Calculate</button>
-    </div>
-    <div id="results"></div>
+          </select>
+        </div>
+      </div>
 
-    <script src="script.js"></script> <!-- Link to JavaScript -->
-</body>
-<body><p>Updated 1.13.2025</p>
-  <p>Created by Nickolas Mancini, MD, MBA</p></body>
-<!-- partial -->
-  <script  src="./script.js"></script>
+      <button type="button" onclick="calculateDose()">Calculate</button>
+    </section>
 
+    <section id="results" class="panel" aria-live="polite"></section>
+
+    <section class="panel carousel-section" data-carousel>
+      <h2>Acetaminophen Product Labels</h2>
+      <div class="carousel-track">
+        <figure class="carousel-slide">
+          <img src="images/acetaminophen-tylenol.svg" alt="Tylenol infant acetaminophen 160 mg per 5 mL oral suspension label" />
+          <figcaption>Tylenol<sup>&reg;</sup> Infant Oral Suspension (160 mg per 5 mL)</figcaption>
+        </figure>
+        <figure class="carousel-slide">
+          <img src="images/acetaminophen-generic.svg" alt="Generic infants acetaminophen 160 mg per 5 mL oral suspension label" />
+          <figcaption>Store Brand Infant Acetaminophen (160 mg per 5 mL)</figcaption>
+        </figure>
+      </div>
+      <div class="carousel-controls">
+        <button type="button" data-carousel-prev aria-label="Show previous acetaminophen product">&#8592;</button>
+        <div class="carousel-dots" aria-hidden="true"></div>
+        <button type="button" data-carousel-next aria-label="Show next acetaminophen product">&#8594;</button>
+      </div>
+    </section>
+
+    <section class="panel carousel-section" data-carousel>
+      <h2>Ibuprofen Product Labels</h2>
+      <div class="carousel-track">
+        <figure class="carousel-slide">
+          <img src="images/ibuprofen-infant.svg" alt="Infant's Motrin ibuprofen 50 mg per 1.25 mL label" />
+          <figcaption>Infant's Motrin<sup>&reg;</sup> Concentrated Drops (50 mg per 1.25 mL)</figcaption>
+        </figure>
+        <figure class="carousel-slide">
+          <img src="images/ibuprofen-children.svg" alt="Children's Advil ibuprofen 100 mg per 5 mL label" />
+          <figcaption>Children's Advil<sup>&reg;</sup> Suspension (100 mg per 5 mL)</figcaption>
+        </figure>
+      </div>
+      <div class="carousel-controls">
+        <button type="button" data-carousel-prev aria-label="Show previous ibuprofen product">&#8592;</button>
+        <div class="carousel-dots" aria-hidden="true"></div>
+        <button type="button" data-carousel-next aria-label="Show next ibuprofen product">&#8594;</button>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <p><strong>Disclaimer:</strong> This tool is for educational purposes only and is not a substitute for professional medical advice. Always confirm dosing with your pediatrician or pharmacist before administering medication.</p>
+    <p>Updated 1.13.2025 &bull; Created by Nickolas Mancini, MD, MBA</p>
+  </footer>
+
+  <script src="./script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,60 +1,157 @@
-function updateForm() {
-    const age = document.getElementById('age').value;
-    const message = document.getElementById('message');
-    const form = document.getElementById('form');
-    const results = document.getElementById('results');
-    
-    message.style.display = 'none';
-    form.style.display = 'block';
-    results.innerHTML = '';
+function getElements() {
+  return {
+    ageSelect: document.getElementById('age'),
+    weightInput: document.getElementById('weight'),
+    weightUnit: document.getElementById('weight-unit'),
+    message: document.getElementById('message'),
+    results: document.getElementById('results'),
+    calculateButton: document.querySelector('#calculator button'),
+  };
+}
 
-    if (age === '0-2') {
-        message.style.display = 'block';
-        message.innerHTML = 
-            'If a child <60 days of age has a fever it is a medical emergency: ' + 
-            'contact your primary care provider and/or present for evaluation by a healthcare provider.';
-        form.style.display = 'none';
-    }
+function clearResults(elements) {
+  elements.results.innerHTML = '';
+}
+
+function updateForm() {
+  const elements = getElements();
+  const age = elements.ageSelect.value;
+
+  clearResults(elements);
+  elements.message.hidden = true;
+  elements.message.innerHTML = '';
+  elements.calculateButton.disabled = false;
+  elements.weightInput.disabled = false;
+  elements.weightUnit.disabled = false;
+
+  if (age === '0-2') {
+    elements.message.hidden = false;
+    elements.message.innerHTML =
+      'If a child less than 60 days old has a fever it is a medical emergency. ' +
+      'Please contact your pediatrician or seek care with a healthcare provider immediately.';
+
+    elements.calculateButton.disabled = true;
+    elements.weightInput.disabled = true;
+    elements.weightUnit.disabled = true;
+  }
 }
 
 function calculateDose() {
-    const age = document.getElementById('age').value;
-    const weightInput = parseFloat(document.getElementById('weight').value);
-    const weightUnit = document.getElementById('weight-unit').value;
-    const results = document.getElementById('results');
-    results.innerHTML = '';
+  const elements = getElements();
+  const age = elements.ageSelect.value;
+  const weightInput = parseFloat(elements.weightInput.value);
+  const weightUnit = elements.weightUnit.value;
 
-    if (isNaN(weightInput) || weightInput <= 0) {
-        results.innerHTML = '<p><strong>Please enter a valid weight.</strong></p>';
-        return;
-    }
+  clearResults(elements);
 
-    // Convert weight to kg if it's in lbs
-    const weight = weightUnit === 'lbs' ? weightInput / 2.20462 : weightInput;
+  if (!age) {
+    elements.results.innerHTML = '<p><strong>Please select an age group to continue.</strong></p>';
+    return;
+  }
 
-    if (age === '2-6') {
-        const acetaminophenDoseMg = 12.5 * weight;
-        const acetaminophenMl = (acetaminophenDoseMg / 160) * 5;
-        results.innerHTML = `
-            <p><strong>Acetaminophen [160mg/5ml]:</strong><br>
-            ${acetaminophenMl.toFixed(1)} ml (${acetaminophenDoseMg.toFixed(1)} mg) every 4 hours as needed for fever/pain.</p>
-        `;
-    } else if (age === '6+') {
-        const acetaminophenDoseMg = 15 * weight;
-        const acetaminophenMl = (acetaminophenDoseMg / 160) * 5;
-        const ibuprofenDoseMg = 10 * weight;
-        const ibuprofenMl50 = (ibuprofenDoseMg / 50) * 1.25;
-        const ibuprofenMl100 = (ibuprofenDoseMg / 100) * 5;
+  if (isNaN(weightInput) || weightInput <= 0) {
+    elements.results.innerHTML = '<p><strong>Please enter a valid weight.</strong></p>';
+    return;
+  }
 
-        results.innerHTML = `
-            <p><strong>Acetaminophen [160mg/5ml]:</strong><br>
-            ${acetaminophenMl.toFixed(1)} ml (${acetaminophenDoseMg.toFixed(1)} mg) every 6 hours as needed for fever/pain.</p>
-            <br>
-            <p><strong>Ibuprofen (Infant's) [50mg/1.25ml]:</strong><br>
-            ${ibuprofenMl50.toFixed(1)} ml (${ibuprofenDoseMg.toFixed(1)} mg) every 6 hours as needed for fever/pain.</p>
-            <br>
-            <p><strong>Ibuprofen (Children's) [100mg/5ml]:</strong><br>
-            ${ibuprofenMl100.toFixed(1)} ml (${ibuprofenDoseMg.toFixed(1)} mg) every 6 hours as needed for fever/pain.</p>
-        `;
-    }
+  const weightKg = weightUnit === 'lbs' ? weightInput / 2.20462 : weightInput;
+  const weightLbs = weightUnit === 'lbs' ? weightInput : weightInput * 2.20462;
+
+  let html = `<p><strong>Patient weight:</strong> ${weightKg.toFixed(1)} kg (${weightLbs.toFixed(1)} lbs)</p>`;
+
+  if (age === '2-6') {
+    const acetaMgCalculated = 12.5 * weightKg;
+    const ACETA_MAX_MG_INFANT = 160;
+    const acetaMg = Math.min(acetaMgCalculated, ACETA_MAX_MG_INFANT);
+    const acetaMl = (acetaMg / 160) * 5;
+    const acetaCapped = acetaMg < acetaMgCalculated;
+
+    html += `
+      <p><strong>Acetaminophen (160 mg / 5 mL)</strong><br>
+      Give ${acetaMl.toFixed(1)} mL (${acetaMg.toFixed(0)} mg) every 4 hours as needed for fever/pain.</p>
+      <p class="dose-note">Maximum single dose for this age group is ${ACETA_MAX_MG_INFANT} mg.${
+        acetaCapped
+          ? ' Weight-based dose was limited to this maximum. Consider discussing dosing with your pediatrician.'
+          : ''
+      }</p>
+    `;
+  } else if (age === '6+') {
+    const ACETA_MAX_MG_CHILD = 1000;
+    const IBU_MAX_MG_CHILD = 400;
+
+    const acetaMgCalculated = 15 * weightKg;
+    const acetaMg = Math.min(acetaMgCalculated, ACETA_MAX_MG_CHILD);
+    const acetaMl = (acetaMg / 160) * 5;
+    const acetaCapped = acetaMg < acetaMgCalculated;
+
+    const ibuMgCalculated = 10 * weightKg;
+    const ibuMg = Math.min(ibuMgCalculated, IBU_MAX_MG_CHILD);
+    const ibuCapped = ibuMg < ibuMgCalculated;
+    const ibuMl50 = (ibuMg / 50) * 1.25;
+    const ibuMl100 = (ibuMg / 100) * 5;
+
+    html += `
+      <p><strong>Acetaminophen (160 mg / 5 mL)</strong><br>
+      Give ${acetaMl.toFixed(1)} mL (${acetaMg.toFixed(0)} mg) every 6 hours as needed for fever/pain.</p>
+      <p class="dose-note">Maximum single dose for this age group is ${ACETA_MAX_MG_CHILD} mg.${
+        acetaCapped
+          ? ' Weight-based dose was limited to this maximum. Consider discussing dosing with your pediatrician.'
+          : ''
+      }</p>
+      <p><strong>Ibuprofen (Infant's 50 mg / 1.25 mL)</strong><br>
+      Give ${ibuMl50.toFixed(1)} mL (${ibuMg.toFixed(0)} mg) every 6 hours as needed for fever/pain.</p>
+      <p><strong>Ibuprofen (Children's 100 mg / 5 mL)</strong><br>
+      Give ${ibuMl100.toFixed(1)} mL (${ibuMg.toFixed(0)} mg) every 6 hours as needed for fever/pain.</p>
+      <p class="dose-note">Maximum single dose for this age group is ${IBU_MAX_MG_CHILD} mg.${
+        ibuCapped
+          ? ' Weight-based dose was limited to this maximum. Consider discussing dosing with your pediatrician.'
+          : ''
+      }</p>
+    `;
+  }
+
+  elements.results.innerHTML = html;
 }
+
+// Initialize state on first load
+updateForm();
+
+function initCarousels() {
+  const carousels = document.querySelectorAll('[data-carousel]');
+
+  carousels.forEach((carousel) => {
+    const slides = Array.from(carousel.querySelectorAll('.carousel-slide'));
+    if (slides.length === 0) return;
+
+    let index = 0;
+
+    const prevButton = carousel.querySelector('[data-carousel-prev]');
+    const nextButton = carousel.querySelector('[data-carousel-next]');
+    const dotsContainer = carousel.querySelector('.carousel-dots');
+
+    const dots = slides.map((_, slideIndex) => {
+      const dot = document.createElement('button');
+      dot.type = 'button';
+      dot.className = 'carousel-dot';
+      dot.setAttribute('aria-label', `Show slide ${slideIndex + 1}`);
+      dot.addEventListener('click', () => goToSlide(slideIndex));
+      dotsContainer?.appendChild(dot);
+      return dot;
+    });
+
+    function goToSlide(newIndex) {
+      slides[index].classList.remove('is-active');
+      dots[index]?.classList.remove('is-active');
+      index = (newIndex + slides.length) % slides.length;
+      slides[index].classList.add('is-active');
+      dots[index]?.classList.add('is-active');
+    }
+
+    prevButton?.addEventListener('click', () => goToSlide(index - 1));
+    nextButton?.addEventListener('click', () => goToSlide(index + 1));
+
+    goToSlide(0);
+  });
+}
+
+window.addEventListener('DOMContentLoaded', initCarousels);

--- a/style.css
+++ b/style.css
@@ -1,140 +1,245 @@
-/* Background styling */
+/* Global layout */
+:root {
+  --overlay: rgba(0, 0, 0, 0.75);
+  --accent: #007bff;
+  --accent-hover: #0056b3;
+  --text-light: #ffffff;
+}
+
+* {
+  box-sizing: border-box;
+}
+
 body {
-    background-image: url('https://nsm0101.github.io/nsm/images/bg2.jpg');
-    background-size: cover;
-    background-repeat: repeat;
-    background-position: top-left;
-    font-family: Arial, sans-serif;
-    color: #fff;
-    margin: 0;
-    padding: 0;
+  margin: 0;
+  min-height: 100vh;
+  font-family: Arial, sans-serif;
+  color: var(--text-light);
+  background-image: url('https://nsm0101.github.io/nsm/images/bg2.jpg');
+  background-size: cover;
+  background-repeat: repeat;
+  background-position: top left;
+  display: flex;
+  flex-direction: column;
 }
 
-/* Styling for message and results */
-#message, #results {
-    background-color: rgba(0, 0, 0, 0.7); 
-
-/* Transparent black background */
-    padding: 20px;
-    border-radius: 8px;
-    max-width: 600px;
-    margin: 20px auto;
-    color: #fff;
+/* Navigation tabs */
+.tabs {
+  display: flex;
+  gap: 12px;
+  padding: 16px;
+  background-color: var(--overlay);
+  flex-wrap: wrap;
 }
 
-/* Center form */
-#form {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    background-color: rgba(0, 0, 0, 0.7);
-    padding: 20px;
-    border-radius: 10px;
-    box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.3);
+.tabs a {
+  color: var(--text-light);
+  text-decoration: none;
+  padding: 10px 18px;
+  border-radius: 999px;
+  background-color: transparent;
+  border: 1px solid transparent;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
 }
 
-/* Select styling */
-select {
-    margin: 10px 0;
-    padding: 10px;
-    width: 30%;
-    border: none;
-    border-radius: 10px;
+.tabs a:hover,
+.tabs a:focus {
+  background-color: rgba(255, 255, 255, 0.15);
+  border-color: rgba(255, 255, 255, 0.3);
 }
 
-/* Input styling */
+.tabs a.active {
+  background-color: var(--accent);
+  border-color: var(--accent);
+}
+
+/* Page layout */
+.page {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 24px 16px 120px;
+  gap: 20px;
+}
+
+.panel {
+  width: min(640px, 100%);
+  background-color: var(--overlay);
+  padding: 24px;
+  border-radius: 12px;
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.35);
+}
+
+#message {
+  width: min(640px, 100%);
+  background-color: rgba(220, 53, 69, 0.9);
+  padding: 18px;
+  border-radius: 12px;
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.35);
+  font-weight: bold;
+  text-align: center;
+}
+
+#calculator h1 {
+  margin-top: 0;
+  font-size: clamp(1.5rem, 2vw + 1rem, 2.25rem);
+  text-align: center;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+label {
+  font-weight: bold;
+}
+
+select,
 input {
-    margin: 10px 0;
-    padding: 11px;
-    width: 35%;
-    border: none;
-    border-radius: 10px;
+  padding: 12px;
+  border-radius: 10px;
+  border: none;
+  background-color: rgba(255, 255, 255, 0.9);
+  color: #000;
+  font-size: 1rem;
 }
 
-/* Button styling */
+select:focus,
+input:focus,
+button:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.weight-input {
+  display: flex;
+  gap: 12px;
+}
+
+.weight-input select {
+  max-width: 120px;
+}
+
 button {
-    padding: 10px;
-    border: none;
-    background-color: #007bff;
-    color: white;
-    cursor: pointer;
-    border-radius: 4px;
-    width: 50%;
+  padding: 12px 24px;
+  border: none;
+  border-radius: 999px;
+  background-color: var(--accent);
+  color: var(--text-light);
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+  width: 100%;
 }
 
 button:hover {
-    background-color: #0056b3;
+  background-color: var(--accent-hover);
 }
 
-
-/* Dropdown Menu */
-.dropdown {
-    position: absolute;
-    top: 10px;
-    left: 10px;
+#results {
+  min-height: 90px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
-.menu-btn {
-    background-color: #fff;
-    color: #000;
-    width:40px;
-    border: none;
-    padding: 10px;
-    font-size: 16px;
-    cursor: pointer;
-    border-radius: 5px;
+#results p {
+  margin: 0;
+  line-height: 1.5;
 }
 
-.dropdown-content {
-    display: none;
-    position: absolute;
-    top: 40px;
-    left: 0;
-    background-color: rgba(0, 0, 0, 0.7);;
-    box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.2);
-    border-radius: 5px;
-    overflow: hidden;
-    z-index: 1000;
+.dose-note {
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.85);
 }
 
-.dropdown-content a {
-    color: #fff;
-    padding: 10px;
-    display: block;
-    text-decoration: none;
+.carousel-section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
 }
 
-.dropdown-content a:hover {
-    background-color: #808080;
+.carousel-track {
+  position: relative;
+  overflow: hidden;
+  border-radius: 12px;
+  background: rgba(0, 0, 0, 0.5);
 }
 
-.menu-btn:hover + .dropdown-content,
-.dropdown-content:hover {
-    display: block;
+.carousel-slide {
+  display: none;
+  padding: 24px;
+  text-align: center;
 }
 
-/* Warning text */
-warning {
-    font-size: 18px;
-    font-weight: bold;
-    color: red;
-    text-align: center;
-    margin: 10px;
+.carousel-slide.is-active {
+  display: block;
 }
 
-/* Footer */
+.carousel-slide img {
+  max-width: min(280px, 100%);
+  width: 100%;
+  height: auto;
+  border-radius: 8px;
+  margin-bottom: 12px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
+}
+
+.carousel-slide figcaption {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.4;
+}
+
+.carousel-controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+
+.carousel-controls button {
+  width: auto;
+  padding-inline: 16px;
+  font-size: 1.25rem;
+}
+
+.carousel-dots {
+  display: flex;
+  gap: 8px;
+}
+
+.carousel-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  border: none;
+  background-color: rgba(255, 255, 255, 0.4);
+  cursor: pointer;
+  padding: 0;
+}
+
+.carousel-dot.is-active {
+  background-color: var(--accent);
+}
+
 footer {
-    position: fixed;
-    bottom: 0;
-    left: 0;
-    width: 100%;
-    padding: 10px;
-    background-color: none;
-    text-align: left;
-    font-size: 14px;
+  padding: 16px;
+  text-align: center;
+  background-color: rgba(0, 0, 0, 0.6);
+  font-size: 0.9rem;
+}
+
+@media (max-width: 600px) {
+  .weight-input {
+    flex-direction: column;
+  }
+
+  .tabs {
+    justify-content: center;
+  }
 }


### PR DESCRIPTION
## Summary
- add maximum single-dose limits to the calculator logic and surface messages when a weight-based dose is capped
- introduce carousel galleries with branded product label imagery for acetaminophen and ibuprofen concentrations across the site
- add legal disclaimers and supporting styles/scripts to reinforce educational use messaging

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cd12beefb483298e5ad7dd6403f05d