### PR TITLE
Fix duplicate homepage sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,20 +9,13 @@
 <body>
   <nav class="tabs">
     <a href="index.html" class="active">Calculator</a>
-
     <a href="medication-guides.html">Medication Guides</a>
-=======
-    <a href="acetaminophen.html">Acetaminophen Guide</a>
-    <a href="ibuprofen.html">Ibuprofen Guide</a>
-
   </nav>
 
   <main class="page">
     <div id="message" role="alert" aria-live="polite" hidden></div>
 
     <section id="calculator" class="panel panel-calculator" aria-labelledby="calculator-heading">
-=======
-    <section id="calculator" class="panel" aria-labelledby="calculator-heading">
 
       <h1 id="calculator-heading">Pain/Fever Medication Dose Calculator</h1>
       <div class="field">
@@ -51,8 +44,6 @@
 
 
     <section id="results" class="panel panel-results" aria-live="polite"></section>
-=======
-    <section id="results" class="panel" aria-live="polite"></section>
 
     <section class="panel carousel-section" data-carousel>
       <h2>Acetaminophen Product Labels</h2>


### PR DESCRIPTION
## Summary
- remove accidental separator text and duplicated sections from the homepage navigation and panels

## Testing
- python - <<'PY'


------
https://chatgpt.com/codex/tasks/task_e_68cd299fb7e48329aae1227e47e83ec4