### PR TITLE
Ensure carousel logic works on older browsers

### DIFF
--- a/script.js
+++ b/script.js
@@ -153,20 +153,30 @@ function initCarousels() {
       dot.className = 'carousel-dot';
       dot.setAttribute('aria-label', `Show slide ${slideIndex + 1}`);
       dot.addEventListener('click', () => goToSlide(slideIndex));
-      dotsContainer?.appendChild(dot);
+      if (dotsContainer) {
+        dotsContainer.appendChild(dot);
+      }
       return dot;
     });
 
     function goToSlide(newIndex) {
       slides[index].classList.remove('is-active');
-      dots[index]?.classList.remove('is-active');
+      if (dots[index]) {
+        dots[index].classList.remove('is-active');
+      }
       index = (newIndex + slides.length) % slides.length;
       slides[index].classList.add('is-active');
-      dots[index]?.classList.add('is-active');
+      if (dots[index]) {
+        dots[index].classList.add('is-active');
+      }
     }
 
-    prevButton?.addEventListener('click', () => goToSlide(index - 1));
-    nextButton?.addEventListener('click', () => goToSlide(index + 1));
+    if (prevButton) {
+      prevButton.addEventListener('click', () => goToSlide(index - 1));
+    }
+    if (nextButton) {
+      nextButton.addEventListener('click', () => goToSlide(index + 1));
+    }
 
     goToSlide(0);
   });


### PR DESCRIPTION
## Summary
- replace optional chaining in carousel initialization with explicit null checks
- keep carousel navigation working while allowing browsers without optional chaining support to run the script

## Testing
- playwright script to select age/weight and verify calculator output


------
https://chatgpt.com/codex/tasks/task_e_68cd2db10dfc83298f38b62492d679ed