### PR TITLE
Add translation overlay with global language options

### DIFF
--- a/acetaminophen.html
+++ b/acetaminophen.html
@@ -11,6 +11,9 @@
     <a href="index.html">Calculator</a>
     <a href="acetaminophen.html" class="active">Acetaminophen Guide</a>
     <a href="ibuprofen.html">Ibuprofen Guide</a>
+    <button type="button" class="tab-button" data-open-translations aria-haspopup="dialog" aria-expanded="false">
+      Translate
+    </button>
   </nav>
 
   <main class="page">
@@ -63,5 +66,32 @@
     <p><strong>Disclaimer:</strong> Educational use only &mdash; confirm dosing with a licensed healthcare professional before giving medication.</p>
     <p>Updated 1.13.2025 &bull; Created by Nickolas Mancini, MD, MBA</p>
   </footer>
+
+  <div class="translation-overlay" id="translation-overlay" hidden aria-hidden="true">
+    <div class="translation-modal" role="dialog" aria-modal="true" aria-labelledby="translation-heading">
+      <button type="button" class="translation-close" data-close-translations aria-label="Close translation options">&times;</button>
+      <div class="translation-hero">
+        <h2 id="translation-heading">Explore Global Language Support</h2>
+        <p>
+          Choose a language below to view this guide through Google Translate. A new tab will open with the translated
+          version of the current page.
+        </p>
+      </div>
+      <div class="translation-options" role="list">
+        <button type="button" class="translation-option" data-translate="es" data-lang-name="Spanish">Spanish</button>
+        <button type="button" class="translation-option" data-translate="pt" data-lang-name="Portuguese">Portuguese</button>
+        <button type="button" class="translation-option" data-translate="fr" data-lang-name="French">French</button>
+        <button type="button" class="translation-option" data-translate="de" data-lang-name="German">German</button>
+        <button type="button" class="translation-option" data-translate="it" data-lang-name="Italian">Italian</button>
+        <button type="button" class="translation-option" data-translate="zh-CN" data-lang-name="Chinese">Chinese</button>
+        <button type="button" class="translation-option" data-translate="ru" data-lang-name="Russian">Russian</button>
+        <button type="button" class="translation-option" data-translate="ar" data-lang-name="Arabic">Arabic</button>
+        <button type="button" class="translation-option" data-translate="rw" data-lang-name="Rwandan">Rwandan</button>
+      </div>
+      <p class="translation-status" data-selection-status aria-live="polite"></p>
+    </div>
+  </div>
+
+  <script src="./script.js"></script>
 </body>
 </html>

--- a/ibuprofen.html
+++ b/ibuprofen.html
@@ -11,6 +11,9 @@
     <a href="index.html">Calculator</a>
     <a href="acetaminophen.html">Acetaminophen Guide</a>
     <a href="ibuprofen.html" class="active">Ibuprofen Guide</a>
+    <button type="button" class="tab-button" data-open-translations aria-haspopup="dialog" aria-expanded="false">
+      Translate
+    </button>
   </nav>
 
   <main class="page">
@@ -62,5 +65,32 @@
     <p><strong>Disclaimer:</strong> Educational use only &mdash; confirm dosing with a licensed healthcare professional before giving medication.</p>
     <p>Updated 1.13.2025 &bull; Created by Nickolas Mancini, MD, MBA</p>
   </footer>
+
+  <div class="translation-overlay" id="translation-overlay" hidden aria-hidden="true">
+    <div class="translation-modal" role="dialog" aria-modal="true" aria-labelledby="translation-heading">
+      <button type="button" class="translation-close" data-close-translations aria-label="Close translation options">&times;</button>
+      <div class="translation-hero">
+        <h2 id="translation-heading">Explore Global Language Support</h2>
+        <p>
+          Choose a language below to view this guide through Google Translate. A new tab will open with the translated
+          version of the current page.
+        </p>
+      </div>
+      <div class="translation-options" role="list">
+        <button type="button" class="translation-option" data-translate="es" data-lang-name="Spanish">Spanish</button>
+        <button type="button" class="translation-option" data-translate="pt" data-lang-name="Portuguese">Portuguese</button>
+        <button type="button" class="translation-option" data-translate="fr" data-lang-name="French">French</button>
+        <button type="button" class="translation-option" data-translate="de" data-lang-name="German">German</button>
+        <button type="button" class="translation-option" data-translate="it" data-lang-name="Italian">Italian</button>
+        <button type="button" class="translation-option" data-translate="zh-CN" data-lang-name="Chinese">Chinese</button>
+        <button type="button" class="translation-option" data-translate="ru" data-lang-name="Russian">Russian</button>
+        <button type="button" class="translation-option" data-translate="ar" data-lang-name="Arabic">Arabic</button>
+        <button type="button" class="translation-option" data-translate="rw" data-lang-name="Rwandan">Rwandan</button>
+      </div>
+      <p class="translation-status" data-selection-status aria-live="polite"></p>
+    </div>
+  </div>
+
+  <script src="./script.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -10,6 +10,9 @@
   <nav class="tabs">
     <a href="index.html" class="active">Calculator</a>
     <a href="medication-guides.html">Medication Guides</a>
+    <button type="button" class="tab-button" data-open-translations aria-haspopup="dialog" aria-expanded="false">
+      Translate
+    </button>
   </nav>
 
   <main class="page">
@@ -88,6 +91,31 @@
     <p><strong>Disclaimer:</strong> This tool is for educational purposes only and is not a substitute for professional medical advice. Always confirm dosing with your pediatrician or pharmacist before administering medication.</p>
     <p>Updated 1.13.2025 &bull; Created by Nickolas Mancini, MD, MBA</p>
   </footer>
+
+  <div class="translation-overlay" id="translation-overlay" hidden aria-hidden="true">
+    <div class="translation-modal" role="dialog" aria-modal="true" aria-labelledby="translation-heading">
+      <button type="button" class="translation-close" data-close-translations aria-label="Close translation options">&times;</button>
+      <div class="translation-hero">
+        <h2 id="translation-heading">Explore Global Language Support</h2>
+        <p>
+          Choose a language below to view this guide through Google Translate. A new tab will open with the translated
+          version of the current page.
+        </p>
+      </div>
+      <div class="translation-options" role="list">
+        <button type="button" class="translation-option" data-translate="es" data-lang-name="Spanish">Spanish</button>
+        <button type="button" class="translation-option" data-translate="pt" data-lang-name="Portuguese">Portuguese</button>
+        <button type="button" class="translation-option" data-translate="fr" data-lang-name="French">French</button>
+        <button type="button" class="translation-option" data-translate="de" data-lang-name="German">German</button>
+        <button type="button" class="translation-option" data-translate="it" data-lang-name="Italian">Italian</button>
+        <button type="button" class="translation-option" data-translate="zh-CN" data-lang-name="Chinese">Chinese</button>
+        <button type="button" class="translation-option" data-translate="ru" data-lang-name="Russian">Russian</button>
+        <button type="button" class="translation-option" data-translate="ar" data-lang-name="Arabic">Arabic</button>
+        <button type="button" class="translation-option" data-translate="rw" data-lang-name="Rwandan">Rwandan</button>
+      </div>
+      <p class="translation-status" data-selection-status aria-live="polite"></p>
+    </div>
+  </div>
 
   <script src="./script.js"></script>
 </body>

--- a/medication-guides.html
+++ b/medication-guides.html
@@ -10,6 +10,9 @@
   <nav class="tabs">
     <a href="index.html">Calculator</a>
     <a href="medication-guides.html" class="active">Medication Guides</a>
+    <button type="button" class="tab-button" data-open-translations aria-haspopup="dialog" aria-expanded="false">
+      Translate
+    </button>
   </nav>
 
   <main class="page">
@@ -97,6 +100,31 @@
     <p><strong>Disclaimer:</strong> This tool is for educational purposes only and is not a substitute for professional medical advice. Always confirm dosing with your pediatrician or pharmacist before administering medication.</p>
     <p>Updated 1.13.2025 &bull; Created by Nickolas Mancini, MD, MBA</p>
   </footer>
+
+  <div class="translation-overlay" id="translation-overlay" hidden aria-hidden="true">
+    <div class="translation-modal" role="dialog" aria-modal="true" aria-labelledby="translation-heading">
+      <button type="button" class="translation-close" data-close-translations aria-label="Close translation options">&times;</button>
+      <div class="translation-hero">
+        <h2 id="translation-heading">Explore Global Language Support</h2>
+        <p>
+          Choose a language below to view this guide through Google Translate. A new tab will open with the translated
+          version of the current page.
+        </p>
+      </div>
+      <div class="translation-options" role="list">
+        <button type="button" class="translation-option" data-translate="es" data-lang-name="Spanish">Spanish</button>
+        <button type="button" class="translation-option" data-translate="pt" data-lang-name="Portuguese">Portuguese</button>
+        <button type="button" class="translation-option" data-translate="fr" data-lang-name="French">French</button>
+        <button type="button" class="translation-option" data-translate="de" data-lang-name="German">German</button>
+        <button type="button" class="translation-option" data-translate="it" data-lang-name="Italian">Italian</button>
+        <button type="button" class="translation-option" data-translate="zh-CN" data-lang-name="Chinese">Chinese</button>
+        <button type="button" class="translation-option" data-translate="ru" data-lang-name="Russian">Russian</button>
+        <button type="button" class="translation-option" data-translate="ar" data-lang-name="Arabic">Arabic</button>
+        <button type="button" class="translation-option" data-translate="rw" data-lang-name="Rwandan">Rwandan</button>
+      </div>
+      <p class="translation-status" data-selection-status aria-live="polite"></p>
+    </div>
+  </div>
 
   <script src="./script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -182,7 +182,103 @@ function initCarousels() {
   });
 }
 
+function initTranslations() {
+  const trigger = document.querySelector('[data-open-translations]');
+  const overlay = document.getElementById('translation-overlay');
+  if (!trigger || !overlay) {
+    return;
+  }
+
+  const closeButton = overlay.querySelector('[data-close-translations]');
+  const status = overlay.querySelector('[data-selection-status]');
+  const languageButtons = overlay.querySelectorAll('[data-translate]');
+  let lastFocusedElement = null;
+
+  function setExpanded(isExpanded) {
+    trigger.setAttribute('aria-expanded', String(isExpanded));
+    overlay.setAttribute('aria-hidden', String(!isExpanded));
+  }
+
+  function openOverlay() {
+    if (!overlay.hidden) {
+      return;
+    }
+    lastFocusedElement = document.activeElement;
+    overlay.hidden = false;
+    requestAnimationFrame(() => {
+      overlay.classList.add('is-visible');
+    });
+    document.body.style.overflow = 'hidden';
+    setExpanded(true);
+    const firstButton = overlay.querySelector('[data-translate]');
+    if (firstButton) {
+      firstButton.focus();
+    }
+  }
+
+  function closeOverlay() {
+    if (overlay.hidden) {
+      return;
+    }
+    overlay.classList.remove('is-visible');
+    setExpanded(false);
+    document.body.style.overflow = '';
+    if (status) {
+      status.textContent = '';
+    }
+    setTimeout(() => {
+      overlay.hidden = true;
+      if (lastFocusedElement) {
+        lastFocusedElement.focus();
+      }
+    }, 250);
+  }
+
+  trigger.addEventListener('click', () => {
+    if (overlay.hidden) {
+      openOverlay();
+    } else {
+      closeOverlay();
+    }
+  });
+
+  if (closeButton) {
+    closeButton.addEventListener('click', () => closeOverlay());
+  }
+
+  overlay.addEventListener('click', (event) => {
+    if (event.target === overlay) {
+      closeOverlay();
+    }
+  });
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape' && !overlay.hidden) {
+      closeOverlay();
+    }
+  });
+
+  const translationBase = 'https://translate.google.com/translate';
+
+  languageButtons.forEach((button) => {
+    button.addEventListener('click', () => {
+      const languageCode = button.getAttribute('data-translate');
+      const languageName = button.getAttribute('data-lang-name');
+      if (!languageCode) {
+        return;
+      }
+
+      const url = `${translationBase}?sl=en&tl=${encodeURIComponent(languageCode)}&u=${encodeURIComponent(window.location.href)}`;
+      window.open(url, '_blank', 'noopener');
+      if (status && languageName) {
+        status.textContent = `${languageName} translation opening in a new tab.`;
+      }
+    });
+  });
+}
+
 window.addEventListener('DOMContentLoaded', () => {
   initCarousels();
   updateForm();
+  initTranslations();
 });

--- a/style.css
+++ b/style.css
@@ -32,7 +32,8 @@ body {
   flex-wrap: wrap;
 }
 
-.tabs a {
+.tabs a,
+.tabs button {
   color: var(--text-light);
   text-decoration: none;
   padding: 10px 18px;
@@ -40,10 +41,14 @@ body {
   background-color: transparent;
   border: 1px solid transparent;
   transition: background-color 0.2s ease, border-color 0.2s ease;
+  font: inherit;
+  cursor: pointer;
 }
 
 .tabs a:hover,
-.tabs a:focus {
+.tabs a:focus,
+.tabs button:hover,
+.tabs button:focus {
   background-color: rgba(255, 255, 255, 0.15);
   border-color: rgba(255, 255, 255, 0.3);
 }
@@ -51,6 +56,17 @@ body {
 .tabs a.active {
   background-color: var(--accent);
   border-color: var(--accent);
+}
+
+.tabs button {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: auto;
+  background-color: transparent;
+  border: 1px solid transparent;
+  padding: 10px 18px;
+  border-radius: 999px;
 }
 
 /* Page layout */
@@ -154,6 +170,115 @@ button {
 
 button:hover {
   background-color: var(--accent-hover);
+}
+
+.translation-overlay[hidden] {
+  display: none;
+}
+
+.translation-overlay {
+  position: fixed;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(0, 32, 64, 0.92), rgba(0, 0, 0, 0.85));
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 32px 16px;
+  z-index: 1000;
+  opacity: 0;
+  transform: scale(1.02);
+  transition: opacity 0.25s ease, transform 0.3s ease;
+}
+
+.translation-overlay.is-visible {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.translation-modal {
+  position: relative;
+  width: min(960px, 100%);
+  background: rgba(7, 29, 54, 0.92);
+  border-radius: 24px;
+  padding: clamp(24px, 3vw, 48px);
+  box-shadow: 0 30px 60px rgba(0, 0, 0, 0.5);
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+}
+
+.translation-close {
+  position: absolute;
+  top: 18px;
+  right: 18px;
+  background: rgba(0, 0, 0, 0.35);
+  border: none;
+  color: var(--text-light);
+  font-size: 1.75rem;
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+}
+
+.translation-close:hover,
+.translation-close:focus {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.translation-hero {
+  text-align: center;
+  display: grid;
+  gap: 16px;
+}
+
+.translation-hero h2 {
+  margin: 0;
+  font-size: clamp(1.8rem, 1.5vw + 1.6rem, 2.4rem);
+}
+
+.translation-hero p {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.8);
+  font-size: 1.05rem;
+}
+
+.translation-options {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 16px;
+}
+
+.translation-option {
+  border-radius: 18px;
+  padding: 18px 14px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: linear-gradient(160deg, rgba(0, 123, 255, 0.25), rgba(0, 0, 0, 0.5));
+  color: var(--text-light);
+  font-size: 1.05rem;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  font-weight: bold;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.3s ease;
+}
+
+.translation-option:hover,
+.translation-option:focus {
+  transform: translateY(-4px);
+  box-shadow: 0 18px 32px rgba(0, 0, 0, 0.35);
+  background: linear-gradient(160deg, rgba(0, 123, 255, 0.55), rgba(0, 0, 0, 0.6));
+}
+
+.translation-status {
+  margin: 0;
+  text-align: center;
+  font-size: 1rem;
+  color: rgba(173, 216, 230, 0.85);
+  min-height: 1.5em;
 }
 
 #results {


### PR DESCRIPTION
## Summary
- add a Translate tab to the top navigation on every page and wire it to a reusable splash-style overlay for language selection
- style the overlay to mimic a modern splash panel and present buttons for Spanish, Portuguese, French, German, Italian, Chinese, Russian, Arabic, and Rwandan translations
- hook up client-side scripting to open Google Translate in a new tab for the chosen language, manage focus, and close the overlay gracefully

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd3a0cc72c83298d17a8321872086c