### PR TITLE
Restore calculator functionality and medication guide carousels

### DIFF
--- a/medication-guides.html
+++ b/medication-guides.html
@@ -24,9 +24,9 @@
       </p>
       <div class="guide-grid">
         <article class="guide-card">
-          <h2><ul>Acetaminophen</ul></h2>
+          <h2>Acetaminophen</h2>
           <section class="carousel-section" data-carousel>
-            <h3>Acetaminophen Care Gallery</h3>
+            <h3>Children's Tylenol (160 mg / 5 mL)</h3>
             <div class="carousel-track">
               <figure class="carousel-slide">
                 <img src="images/Acetaminophen/Tylenol acetaminophen iso.png" alt="Parent checking a child's temperature beside acetaminophen supplies" />
@@ -51,7 +51,6 @@
               <button type="button" data-carousel-next aria-label="Show next acetaminophen product">&#8594;</button>
             </div>
           </section>
-          </ul>
           <h3>Safety Tips:</h3>
           <ul>
             <li>Do not exceed 6 doses in 24 hours.</li>
@@ -62,10 +61,10 @@
           </ul>
         </article>
         <article class="guide-card">
-          <h2><ul>Ibuprofen</ul></h2>
+          <h2>Ibuprofen</h2>
           <div class="guide-subgrid">
             <section class="guide-subcard">
-              <h3><ul>Children's Ibuprofen (100 mg / 5 mL)</ul></h3>
+              <h3>Children's Ibuprofen (100 mg / 5 mL)</h3>
               <section class="carousel-section carousel-compact" data-carousel>
                 <h4 class="visually-hidden">Children's ibuprofen product labels</h4>
                 <div class="carousel-track">
@@ -87,7 +86,7 @@
                   </figure>
                   <figure class="carousel-slide">
                     <img src="images/Ibuprofen/Equate Children ibuprofen iso.png" alt="Equate" />
-                    <figcaption>Equate<sup>&reg;</sup> Children's Ibuprofenn</figcaption>
+                    <figcaption>Equate<sup>&reg;</sup> Children's Ibuprofen</figcaption>
                   </figure>
                 </div>
                 <div class="carousel-controls">
@@ -99,12 +98,12 @@
               <p>Standard children's suspension dosed using an oral syringe or medicine cup. Verify strength before dosing.</p>
             </section>
             <section class="guide-subcard">
-              <h3><ul>Infant Drops (50 mg / 1.25 mL)</ul></h3>
+              <h3>Infant Drops (50 mg / 1.25 mL)</h3>
               <section class="carousel-section carousel-compact" data-carousel>
                 <h4 class="visually-hidden">Infant ibuprofen product labels</h4>
                 <div class="carousel-track">
                   <figure class="carousel-slide">
-                    <img src="Motrin Infant ibuprofen iso.png" alt="Motrin" />
+                    <img src="images/Ibuprofen/Infants/Motrin Infant ibuprofen iso.png" alt="Motrin" />
                     <figcaption>Motrin<sup>&reg;</sup> Infants' Concentrated Drops</figcaption>
                   </figure>
                   <figure class="carousel-slide">

--- a/script.js
+++ b/script.js
@@ -141,7 +141,7 @@ function initCarousels() {
     const slides = Array.from(carousel.querySelectorAll('.carousel-slide'));
     if (slides.length === 0) return;
 
-    let index = 0;
+    let index = -1;
 
     const prevButton = carousel.querySelector('[data-carousel-prev]');
     const nextButton = carousel.querySelector('[data-carousel-next]');
@@ -160,10 +160,13 @@ function initCarousels() {
     });
 
     function goToSlide(newIndex) {
-      slides[index].classList.remove('is-active');
-      if (dots[index]) {
-        dots[index].classList.remove('is-active');
+      if (index >= 0) {
+        slides[index].classList.remove('is-active');
+        if (dots[index]) {
+          dots[index].classList.remove('is-active');
+        }
       }
+
       index = (newIndex + slides.length) % slides.length;
       slides[index].classList.add('is-active');
       if (dots[index]) {
@@ -198,6 +201,8 @@ function initTranslations() {
     trigger.setAttribute('aria-expanded', String(isExpanded));
     overlay.setAttribute('aria-hidden', String(!isExpanded));
   }
+
+  setExpanded(false);
 
   function openOverlay() {
     if (!overlay.hidden) {
@@ -242,6 +247,15 @@ function initTranslations() {
     }
   });
 
+  trigger.addEventListener('keydown', (event) => {
+    if (event.key === ' ' || event.key === 'Enter') {
+      event.preventDefault();
+      if (overlay.hidden) {
+        openOverlay();
+      }
+    }
+  });
+
   if (closeButton) {
     closeButton.addEventListener('click', () => closeOverlay());
   }
@@ -275,15 +289,11 @@ function initTranslations() {
           : `${baseUrl}&tl=${encodeURIComponent(languageCode)}`;
 
       window.open(url, '_blank', 'noopener');
-      if (status && languageName) {
+      if (status) {
         status.textContent =
           languageCode === 'other'
             ? 'Google Translate is opening so you can choose another language.'
-            : `${languageName} translation opening in a new tab.`;
-      const url = `${translationBase}?sl=en&tl=${encodeURIComponent(languageCode)}&u=${encodeURIComponent(window.location.href)}`;
-      window.open(url, '_blank', 'noopener');
-      if (status && languageName) {
-        status.textContent = `${languageName} translation opening in a new tab.`;
+            : `${languageName || 'Selected'} translation opening in a new tab.`;
       }
     });
   });

--- a/style.css
+++ b/style.css
@@ -16,10 +16,12 @@ body {
   min-height: 100vh;
   font-family: Arial, sans-serif;
   color: var(--text-light);
+  background-color: #050505;
   background-image: url('bg.png');
-  background-size: cover;
   background-repeat: no-repeat;
-  background-position: center;
+  background-size: cover;
+  background-position: center top;
+  background-attachment: fixed;
   display: flex;
   flex-direction: column;
 }
@@ -74,25 +76,16 @@ body {
   box-shadow: none;
 }
 
-.tabs button {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  width: auto;
-  background-color: transparent;
-  border: 1px solid transparent;
-  padding: 10px 18px;
-  border-radius: 999px;
-}
-
 /* Page layout */
 .page {
   flex: 1;
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 24px 16px 120px;
+  padding: 32px 16px 120px;
   gap: 20px;
+  width: min(1200px, 100%);
+  margin: 0 auto;
 }
 
 .panel {
@@ -371,63 +364,6 @@ button:active {
   min-height: 1.5em;
 }
 
-.translation-overlay[hidden] {
-  display: none;
-}
-
-.translation-overlay {
-  position: fixed;
-  inset: 0;
-  background: linear-gradient(135deg, rgba(0, 32, 64, 0.92), rgba(0, 0, 0, 0.85));
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  padding: 32px 16px;
-  z-index: 1000;
-  opacity: 0;
-  transform: scale(1.02);
-  transition: opacity 0.25s ease, transform 0.3s ease;
-}
-
-.translation-overlay.is-visible {
-  opacity: 1;
-  transform: scale(1);
-}
-
-.translation-modal {
-  position: relative;
-  width: min(960px, 100%);
-  background: rgba(7, 29, 54, 0.92);
-  border-radius: 24px;
-  padding: clamp(24px, 3vw, 48px);
-  box-shadow: 0 30px 60px rgba(0, 0, 0, 0.5);
-  display: flex;
-  flex-direction: column;
-  gap: 32px;
-  border: 1px solid rgba(255, 255, 255, 0.15);
-}
-
-.translation-close {
-  position: absolute;
-  top: 18px;
-  right: 18px;
-  background: rgba(0, 0, 0, 0.35);
-  border: none;
-  color: var(--text-light);
-  font-size: 1.75rem;
-  width: 42px;
-  height: 42px;
-  border-radius: 50%;
-  cursor: pointer;
-  display: grid;
-  place-items: center;
-}
-
-.translation-close:hover,
-.translation-close:focus {
-  background: rgba(255, 255, 255, 0.2);
-}
-
 .translation-hero {
   text-align: center;
   display: grid;
@@ -544,7 +480,7 @@ button:active {
 
 .guide-subgrid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
   gap: 16px;
 }
 
@@ -712,6 +648,12 @@ footer {
   text-align: center;
   background-color: rgba(0, 0, 0, 0.6);
   font-size: 0.9rem;
+}
+
+@media (min-width: 768px) {
+  .guide-subgrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- fix the translation overlay logic and carousel initialization so the calculator page scripts run without errors
- update the medication guides to restore the Tylenol and ibuprofen image carousels with corrected headings and assets
- adjust global styling to stabilize the background and present the ibuprofen subcards side-by-side on larger screens

## Testing
- node --check script.js

------
https://chatgpt.com/codex/tasks/task_e_68cd59df0c6c8329805cc90ae029bf6f