### PR TITLE
Polish layout and Spanish translation experience

### DIFF
--- a/acetaminophen.html
+++ b/acetaminophen.html
@@ -11,8 +11,8 @@
     <a href="index.html">Calculator</a>
     <a href="acetaminophen.html" class="active">Acetaminophen Guide</a>
     <a href="ibuprofen.html">Ibuprofen Guide</a>
-    <button type="button" class="tab-button" data-open-translations aria-haspopup="dialog" aria-expanded="false">
-      Translate
+    <button type="button" class="tab-button" data-open-translations aria-haspopup="dialog" aria-expanded="false" aria-label="Open Spanish translation">
+      Spanish
     </button>
   </nav>
 
@@ -71,22 +71,14 @@
     <div class="translation-modal" role="dialog" aria-modal="true" aria-labelledby="translation-heading">
       <button type="button" class="translation-close" data-close-translations aria-label="Close translation options">&times;</button>
       <div class="translation-hero">
-        <h2 id="translation-heading">Explore Global Language Support</h2>
+        <h2 id="translation-heading">Ver esta página en Español</h2>
         <p>
-          Choose from our most requested languages&mdash;Spanish, Portuguese, Chinese, Vietnamese, Arabic, and French&mdash;or
-          open Google Translate to pick another language. A new tab will display the translated version of this page.
-          Choose a language below to view this guide through Google Translate. A new tab will open with the translated
-          version of the current page.
+          Abra una versión traducida de esta página en una nueva pestaña mediante Google Translate. Seleccione Español para
+          cargar el contenido completo en ese idioma.
         </p>
       </div>
       <div class="translation-options" role="list">
-        <button type="button" class="translation-option" data-translate="es" data-lang-name="Spanish">Spanish</button>
-        <button type="button" class="translation-option" data-translate="pt" data-lang-name="Portuguese">Portuguese</button>
-        <button type="button" class="translation-option" data-translate="zh-CN" data-lang-name="Chinese">Chinese</button>
-        <button type="button" class="translation-option" data-translate="vi" data-lang-name="Vietnamese">Vietnamese</button>
-        <button type="button" class="translation-option" data-translate="ar" data-lang-name="Arabic">Arabic</button>
-        <button type="button" class="translation-option" data-translate="fr" data-lang-name="French">French</button>
-        <button type="button" class="translation-option" data-translate="other" data-lang-name="Other Languages">Other Languages</button>
+        <button type="button" class="translation-option" data-translate="es" data-lang-name="Español">Español</button>
       </div>
       <p class="translation-status" data-selection-status aria-live="polite"></p>
     </div>

--- a/ibuprofen.html
+++ b/ibuprofen.html
@@ -11,8 +11,8 @@
     <a href="index.html">Calculator</a>
     <a href="acetaminophen.html">Acetaminophen Guide</a>
     <a href="ibuprofen.html" class="active">Ibuprofen Guide</a>
-    <button type="button" class="tab-button" data-open-translations aria-haspopup="dialog" aria-expanded="false">
-      Translate
+    <button type="button" class="tab-button" data-open-translations aria-haspopup="dialog" aria-expanded="false" aria-label="Open Spanish translation">
+      Spanish
     </button>
   </nav>
 
@@ -70,22 +70,14 @@
     <div class="translation-modal" role="dialog" aria-modal="true" aria-labelledby="translation-heading">
       <button type="button" class="translation-close" data-close-translations aria-label="Close translation options">&times;</button>
       <div class="translation-hero">
-        <h2 id="translation-heading">Explore Global Language Support</h2>
+        <h2 id="translation-heading">Ver esta página en Español</h2>
         <p>
-          Choose from our most requested languages&mdash;Spanish, Portuguese, Chinese, Vietnamese, Arabic, and French&mdash;or
-          open Google Translate to pick another language. A new tab will display the translated version of this page.
-          Choose a language below to view this guide through Google Translate. A new tab will open with the translated
-          version of the current page.
+          Abra una versión traducida de esta página en una nueva pestaña mediante Google Translate. Seleccione Español para
+          cargar el contenido completo en ese idioma.
         </p>
       </div>
       <div class="translation-options" role="list">
-        <button type="button" class="translation-option" data-translate="es" data-lang-name="Spanish">Spanish</button>
-        <button type="button" class="translation-option" data-translate="pt" data-lang-name="Portuguese">Portuguese</button>
-        <button type="button" class="translation-option" data-translate="zh-CN" data-lang-name="Chinese">Chinese</button>
-        <button type="button" class="translation-option" data-translate="vi" data-lang-name="Vietnamese">Vietnamese</button>
-        <button type="button" class="translation-option" data-translate="ar" data-lang-name="Arabic">Arabic</button>
-        <button type="button" class="translation-option" data-translate="fr" data-lang-name="French">French</button>
-        <button type="button" class="translation-option" data-translate="other" data-lang-name="Other Languages">Other Languages</button>
+        <button type="button" class="translation-option" data-translate="es" data-lang-name="Español">Español</button>
       </div>
       <p class="translation-status" data-selection-status aria-live="polite"></p>
     </div>

--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@
   <nav class="tabs">
     <a href="index.html" class="active">Calculator</a>
     <a href="medication-guides.html">Medication Guides</a>
-    <button type="button" class="tab-button" data-open-translations aria-haspopup="dialog" aria-expanded="false">
-      Translate
+    <button type="button" class="tab-button" data-open-translations aria-haspopup="dialog" aria-expanded="false" aria-label="Open Spanish translation">
+      Spanish
     </button>
   </nav>
 
@@ -59,22 +59,14 @@
     <div class="translation-modal" role="dialog" aria-modal="true" aria-labelledby="translation-heading">
       <button type="button" class="translation-close" data-close-translations aria-label="Close translation options">&times;</button>
       <div class="translation-hero">
-        <h2 id="translation-heading">Explore Global Language Support</h2>
+        <h2 id="translation-heading">Ver esta página en Español</h2>
         <p>
-          Choose from our most requested languages&mdash;Spanish, Portuguese, Chinese, Vietnamese, Arabic, and French&mdash;or
-          open Google Translate to pick another language. A new tab will display the translated version of this page.
-          Choose a language below to view this guide through Google Translate. A new tab will open with the translated
-          version of the current page.
+          Abra una versión traducida de esta página en una nueva pestaña mediante Google Translate. Seleccione Español para
+          cargar el contenido completo en ese idioma.
         </p>
       </div>
       <div class="translation-options" role="list">
-        <button type="button" class="translation-option" data-translate="es" data-lang-name="Spanish">Spanish</button>
-        <button type="button" class="translation-option" data-translate="pt" data-lang-name="Portuguese">Portuguese</button>
-        <button type="button" class="translation-option" data-translate="zh-CN" data-lang-name="Chinese">Chinese</button>
-        <button type="button" class="translation-option" data-translate="vi" data-lang-name="Vietnamese">Vietnamese</button>
-        <button type="button" class="translation-option" data-translate="ar" data-lang-name="Arabic">Arabic</button>
-        <button type="button" class="translation-option" data-translate="fr" data-lang-name="French">French</button>
-        <button type="button" class="translation-option" data-translate="other" data-lang-name="Other Languages">Other Languages</button>
+        <button type="button" class="translation-option" data-translate="es" data-lang-name="Español">Español</button>
       </div>
       <p class="translation-status" data-selection-status aria-live="polite"></p>
     </div>

--- a/medication-guides.html
+++ b/medication-guides.html
@@ -10,8 +10,8 @@
   <nav class="tabs">
     <a href="index.html">Calculator</a>
     <a href="medication-guides.html" class="active">Medication Guides</a>
-    <button type="button" class="tab-button" data-open-translations aria-haspopup="dialog" aria-expanded="false">
-      Translate
+    <button type="button" class="tab-button" data-open-translations aria-haspopup="dialog" aria-expanded="false" aria-label="Open Spanish translation">
+      Spanish
     </button>
   </nav>
 
@@ -23,7 +23,7 @@
         Always double-check the medication concentration and confirm dosing with your pediatrician or pharmacist.
       </p>
       <div class="guide-grid">
-        <article class="guide-card">
+        <article class="guide-card guide-card-acetaminophen">
           <h2>Acetaminophen</h2>
           <section class="carousel-section" data-carousel>
             <h3>Children's Tylenol (160 mg / 5 mL)</h3>
@@ -51,16 +51,18 @@
               <button type="button" data-carousel-next aria-label="Show next acetaminophen product">&#8594;</button>
             </div>
           </section>
-          <h3>Safety Tips:</h3>
-          <ul>
-            <li>Do not exceed 6 doses in 24 hours.</li>
-            <li><6 months old: dose every 4 hours as needed.</li>
-            <li>>6 months old: dose every 6 hours as needed; may consider alternating dosing with ibuprofen (every 6 hour dosing) to allow medication to be given every 3 hours. </li>
-            <li>Contact a healthcare provider for children under 2 months of age with a fever or for persistent fever >3 days.</li>
-            <li>Keep a log of medication given, time, and dose to avoid accidental repeat dosing.</li>
-          </ul>
+          <div class="acetaminophen-safety">
+            <h3>Safety Tips</h3>
+            <ul>
+              <li>Do not exceed 6 doses in 24 hours.</li>
+              <li>&lt;6 months old: dose every 4 hours as needed.</li>
+              <li>&gt;6 months old: dose every 6 hours as needed; may consider alternating dosing with ibuprofen (every 6 hour dosing) to allow medication to be given every 3 hours. </li>
+              <li>Contact a healthcare provider for children under 2 months of age with a fever or for persistent fever &gt;3 days.</li>
+              <li>Keep a log of medication given, time, and dose to avoid accidental repeat dosing.</li>
+            </ul>
+          </div>
         </article>
-        <article class="guide-card">
+        <article class="guide-card guide-card-ibuprofen">
           <h2>Ibuprofen</h2>
           <div class="guide-subgrid">
             <section class="guide-subcard">
@@ -132,7 +134,7 @@
               <p>Highly concentrated infant drops dosed with the included dropper.</p>
             </section>
           </div>
-          <h3>Safety Tips:</h3>
+          <h3>Safety Tips</h3>
           <ul>
             <li>Do not use in infants under 6 months unless directed by a doctor.</li>
             <li>Allow at least 6 hours between doses.</li>
@@ -154,23 +156,14 @@
     <div class="translation-modal" role="dialog" aria-modal="true" aria-labelledby="translation-heading">
       <button type="button" class="translation-close" data-close-translations aria-label="Close translation options">&times;</button>
       <div class="translation-hero">
-        <h2 id="translation-heading">Explore Global Language Support</h2>
+        <h2 id="translation-heading">Ver esta página en Español</h2>
         <p>
-          Choose from our most requested languages&mdash;Spanish, Portuguese, Chinese, Vietnamese, Arabic, and French&mdash;or
-          open Google Translate to pick another language. A new tab will display the translated version of this page.
-                                                  
-          Choose a language below to view this guide through Google Translate. A new tab will open with the translated
-          version of the current page.
+          Abra una versión traducida de esta página en una nueva pestaña mediante Google Translate. Seleccione Español para
+          cargar el contenido completo en ese idioma.
         </p>
       </div>
       <div class="translation-options" role="list">
-        <button type="button" class="translation-option" data-translate="es" data-lang-name="Spanish">Spanish</button>
-        <button type="button" class="translation-option" data-translate="pt" data-lang-name="Portuguese">Portuguese</button>
-        <button type="button" class="translation-option" data-translate="zh-CN" data-lang-name="Chinese">Chinese</button>
-        <button type="button" class="translation-option" data-translate="vi" data-lang-name="Vietnamese">Vietnamese</button>
-        <button type="button" class="translation-option" data-translate="ar" data-lang-name="Arabic">Arabic</button>
-        <button type="button" class="translation-option" data-translate="fr" data-lang-name="French">French</button>
-        <button type="button" class="translation-option" data-translate="other" data-lang-name="Other Languages">Other Languages</button>
+        <button type="button" class="translation-option" data-translate="es" data-lang-name="Español">Español</button>
       </div>
       <p class="translation-status" data-selection-status aria-live="polite"></p>
     </div>

--- a/script.js
+++ b/script.js
@@ -141,6 +141,11 @@ function initCarousels() {
     const slides = Array.from(carousel.querySelectorAll('.carousel-slide'));
     if (slides.length === 0) return;
 
+    slides.forEach((slide) => {
+      slide.classList.remove('is-active');
+      slide.setAttribute('aria-hidden', 'true');
+    });
+
     let index = -1;
 
     const prevButton = carousel.querySelector('[data-carousel-prev]');
@@ -152,6 +157,7 @@ function initCarousels() {
       dot.type = 'button';
       dot.className = 'carousel-dot';
       dot.setAttribute('aria-label', `Show slide ${slideIndex + 1}`);
+      dot.setAttribute('aria-pressed', 'false');
       dot.addEventListener('click', () => goToSlide(slideIndex));
       if (dotsContainer) {
         dotsContainer.appendChild(dot);
@@ -162,15 +168,27 @@ function initCarousels() {
     function goToSlide(newIndex) {
       if (index >= 0) {
         slides[index].classList.remove('is-active');
+        slides[index].setAttribute('aria-hidden', 'true');
         if (dots[index]) {
           dots[index].classList.remove('is-active');
+          dots[index].setAttribute('aria-pressed', 'false');
         }
       }
 
       index = (newIndex + slides.length) % slides.length;
       slides[index].classList.add('is-active');
+      slides[index].setAttribute('aria-hidden', 'false');
       if (dots[index]) {
         dots[index].classList.add('is-active');
+        dots[index].setAttribute('aria-pressed', 'true');
+      }
+
+      const controlsDisabled = slides.length <= 1;
+      if (prevButton) {
+        prevButton.disabled = controlsDisabled;
+      }
+      if (nextButton) {
+        nextButton.disabled = controlsDisabled;
       }
     }
 
@@ -282,18 +300,13 @@ function initTranslations() {
         return;
       }
 
-      const baseUrl = `${translationBase}?sl=en&u=${encodeURIComponent(window.location.href)}`;
-      const url =
-        languageCode === 'other'
-          ? baseUrl
-          : `${baseUrl}&tl=${encodeURIComponent(languageCode)}`;
+      const url = `${translationBase}?sl=en&tl=${encodeURIComponent(languageCode)}&u=${encodeURIComponent(
+        window.location.href
+      )}`;
 
       window.open(url, '_blank', 'noopener');
       if (status) {
-        status.textContent =
-          languageCode === 'other'
-            ? 'Google Translate is opening so you can choose another language.'
-            : `${languageName || 'Selected'} translation opening in a new tab.`;
+        status.textContent = `${languageName || 'Español'} translation opening in a new tab.`;
       }
     });
   });

--- a/style.css
+++ b/style.css
@@ -1,10 +1,14 @@
 /* Global layout */
 :root {
-  --overlay: rgba(0, 0, 0, 0.75);
-  --accent: #d3d3d3;
-  --accent-hover: #f2f2f2;
-  --accent-shadow: rgba(0, 0, 0, 0.45);
-  --text-light: #ffffff;
+  --overlay: rgba(10, 18, 34, 0.82);
+  --surface: rgba(14, 24, 44, 0.88);
+  --surface-soft: rgba(18, 32, 56, 0.72);
+  --card-border: rgba(255, 255, 255, 0.14);
+  --glow: rgba(84, 190, 255, 0.25);
+  --primary: #4cb8ff;
+  --primary-strong: #2c8df2;
+  --text-light: #f7f9fd;
+  --text-muted: rgba(222, 234, 255, 0.75);
 }
 
 * {
@@ -14,9 +18,9 @@
 body {
   margin: 0;
   min-height: 100vh;
-  font-family: Arial, sans-serif;
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
   color: var(--text-light);
-  background-color: #050505;
+  background-color: #050a14;
   background-image: url('bg.png');
   background-repeat: no-repeat;
   background-size: cover;
@@ -24,6 +28,7 @@ body {
   background-attachment: fixed;
   display: flex;
   flex-direction: column;
+  line-height: 1.6;
 }
 
 /* Navigation tabs */
@@ -68,8 +73,7 @@ body {
   align-items: center;
   gap: 8px;
   width: auto;
-  background-color: transparent;
-  background-image: none;
+  background: transparent;
   border: 1px solid transparent;
   padding: 10px 18px;
   border-radius: 999px;
@@ -89,31 +93,32 @@ body {
 }
 
 .panel {
-  width: min(680px, 100%);
-  background-color: var(--overlay);
-  padding: 24px;
-  border-radius: 16px;
-  box-shadow: 0 12px 36px rgba(0, 0, 0, 0.45);
-  backdrop-filter: blur(2px);
+  width: min(720px, 100%);
+  background: var(--surface);
+  padding: 28px;
+  border-radius: 20px;
+  border: 1px solid var(--card-border);
+  box-shadow: 0 30px 60px rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(14px);
 }
 
 .panel-calculator {
   position: relative;
   overflow: hidden;
-  border: 1px solid rgba(192, 192, 192, 0.6);
-  background: linear-gradient(165deg, rgba(6, 6, 6, 0.98), rgba(32, 32, 32, 0.82));
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: linear-gradient(165deg, rgba(10, 20, 36, 0.96), rgba(20, 38, 66, 0.78));
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.2),
-    inset 0 -14px 28px rgba(0, 0, 0, 0.78),
-    0 24px 48px rgba(0, 0, 0, 0.7);
+    inset 0 1px 0 rgba(255, 255, 255, 0.18),
+    inset 0 -20px 36px rgba(0, 0, 0, 0.65),
+    0 40px 80px rgba(0, 0, 0, 0.7);
 }
 
 .panel-calculator::after {
   content: '';
   position: absolute;
-  inset: 10px;
+  inset: 12px;
   border-radius: inherit;
-  background: linear-gradient(140deg, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0));
+  background: radial-gradient(circle at top left, rgba(92, 191, 255, 0.18), transparent 55%);
   pointer-events: none;
 }
 
@@ -123,8 +128,11 @@ body {
 }
 
 .panel-results {
-  border: 2px solid rgba(255, 255, 255, 0.4);
-  background: linear-gradient(135deg, rgba(0, 0, 0, 0.85), rgba(0, 0, 0, 0.7));
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: linear-gradient(145deg, rgba(12, 22, 40, 0.92), rgba(9, 17, 30, 0.86));
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.1),
+    0 24px 48px rgba(0, 0, 0, 0.58);
 }
 
 .panel-guides {
@@ -132,124 +140,143 @@ body {
 }
 
 #message {
-  width: min(680px, 100%);
-  background: linear-gradient(135deg, rgba(220, 53, 69, 0.92), rgba(120, 20, 30, 0.85));
-  padding: 18px;
-  border-radius: 16px;
-  box-shadow: 0 12px 36px rgba(0, 0, 0, 0.45);
-  border: 2px solid rgba(255, 255, 255, 0.35);
-  font-weight: bold;
+  width: min(720px, 100%);
+  background: linear-gradient(125deg, rgba(255, 102, 120, 0.95), rgba(201, 45, 82, 0.85));
+  padding: 20px 24px;
+  border-radius: 18px;
+  box-shadow: 0 26px 52px rgba(0, 0, 0, 0.5);
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  font-weight: 600;
+  letter-spacing: 0.01em;
   text-align: center;
+}
+
+#calculator {
+  display: grid;
+  gap: 24px;
 }
 
 #calculator h1 {
   margin-top: 0;
-  font-size: clamp(1.5rem, 2vw + 1rem, 2.25rem);
+  font-size: clamp(1.6rem, 2vw + 1.1rem, 2.35rem);
   text-align: center;
+  letter-spacing: 0.01em;
 }
 
 .field {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  margin-bottom: 16px;
+  gap: 10px;
+  padding: 16px 20px;
+  margin: 0;
+  background: linear-gradient(140deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.02));
+  border: 1px solid var(--card-border);
+  border-radius: 16px;
+  box-shadow: 0 18px 34px rgba(0, 0, 0, 0.35);
+  transition: border-color 0.25s ease, box-shadow 0.25s ease;
+}
+
+.field:focus-within {
+  border-color: rgba(76, 184, 255, 0.45);
+  box-shadow: 0 22px 40px rgba(76, 184, 255, 0.15);
 }
 
 label {
-  font-weight: bold;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+  color: var(--text-muted);
 }
 
 select,
 input {
-  padding: 12px;
-  border-radius: 10px;
-  border: none;
-  background-color: rgba(255, 255, 255, 0.9);
-  color: #000;
+  padding: 14px 16px;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-light);
   font-size: 1rem;
+  font-weight: 500;
+  backdrop-filter: blur(12px);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
 }
 
 select:focus,
-input:focus,
-button:focus {
-  outline: 2px solid rgba(255, 255, 255, 0.7);
+input:focus {
+  outline: none;
+  border-color: rgba(76, 184, 255, 0.75);
+  background: rgba(255, 255, 255, 0.18);
+  box-shadow: 0 0 0 4px var(--glow);
+}
+
+button {
+  padding: 12px 24px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-light);
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.25s ease, filter 0.25s ease;
+  width: max-content;
+  border: 1px solid var(--card-border);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.35);
+}
+
+button:hover {
+  background: rgba(255, 255, 255, 0.16);
+  transform: translateY(-1px);
+  box-shadow: 0 18px 34px rgba(0, 0, 0, 0.4);
+}
+
+button:active {
+  transform: translateY(0);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.35);
+}
+
+button:focus-visible {
+  outline: 2px solid rgba(76, 184, 255, 0.7);
   outline-offset: 2px;
-  box-shadow: 0 0 0 3px rgba(211, 211, 211, 0.25);
+  filter: brightness(1.1);
 }
 
 .weight-input {
   display: flex;
   gap: 12px;
+  flex-wrap: wrap;
 }
 
 .weight-input select {
-  max-width: 120px;
-}
-
-button {
-  padding: 12px 24px;
-  border-radius: 999px;
-  background: linear-gradient(140deg, rgba(255, 255, 255, 0.92), rgba(172, 172, 172, 0.95));
-  color: #161616;
-  font-size: 1rem;
-  cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.25s ease;
-  width: 100%;
-  border: 1px solid rgba(255, 255, 255, 0.45);
-  box-shadow:
-    inset 0 2px 0 rgba(255, 255, 255, 0.7),
-    0 12px 24px rgba(0, 0, 0, 0.45);
-}
-
-button:hover {
-  background: linear-gradient(140deg, rgba(255, 255, 255, 0.98), rgba(188, 188, 188, 0.95));
-  transform: translateY(-1px);
-  box-shadow:
-    inset 0 2px 0 rgba(255, 255, 255, 0.75),
-    0 16px 28px rgba(0, 0, 0, 0.45);
-}
-
-button:active {
-  transform: translateY(0);
-  box-shadow:
-    inset 0 2px 4px rgba(0, 0, 0, 0.35),
-    0 10px 20px rgba(0, 0, 0, 0.4);
+  max-width: 140px;
 }
 
 #calculator button {
-  background: linear-gradient(135deg, rgba(245, 245, 245, 0.96), rgba(155, 155, 155, 0.9));
-  border: 1px solid rgba(220, 220, 220, 0.75);
-  color: #060606;
-  font-weight: 600;
+  width: 100%;
+  background: linear-gradient(125deg, var(--primary), var(--primary-strong));
+  border: none;
+  color: #041322;
+  font-weight: 700;
+  letter-spacing: 0.02em;
   box-shadow:
-    inset 0 2px 2px rgba(255, 255, 255, 0.7),
-    0 18px 34px rgba(0, 0, 0, 0.6);
+    0 20px 44px rgba(45, 129, 220, 0.32),
+    0 4px 14px rgba(0, 0, 0, 0.45);
 }
 
 #calculator button:hover {
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.98), rgba(175, 175, 175, 0.92));
+  background: linear-gradient(125deg, var(--primary-strong), #66d4ff);
   box-shadow:
-    inset 0 2px 3px rgba(255, 255, 255, 0.75),
-    0 22px 38px rgba(0, 0, 0, 0.65);
+    0 26px 50px rgba(45, 129, 220, 0.38),
+    0 6px 18px rgba(0, 0, 0, 0.45);
+  transform: translateY(-2px);
 }
 
 #calculator button:active {
-  background: linear-gradient(135deg, rgba(215, 215, 215, 0.95), rgba(140, 140, 140, 0.9));
+  background: linear-gradient(125deg, var(--primary), var(--primary-strong));
+  transform: translateY(0);
   box-shadow:
-    inset 0 3px 5px rgba(0, 0, 0, 0.35),
-    0 14px 24px rgba(0, 0, 0, 0.55);
-}
-
-#calculator input,
-#calculator select {
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.94), rgba(208, 208, 208, 0.9));
-  border: 1px solid rgba(192, 192, 192, 0.6);
-  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.15);
-  color: #0a0a0a;
-}
-
-#calculator select {
-  background-position: right 12px center;
+    0 18px 36px rgba(45, 129, 220, 0.32),
+    0 3px 12px rgba(0, 0, 0, 0.45);
 }
 
 .translation-overlay[hidden] {
@@ -399,6 +426,7 @@ button:active {
   font-weight: bold;
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.3s ease;
+  width: 100%;
 }
 
 .translation-option:hover,
@@ -430,7 +458,7 @@ button:active {
 
 .dose-note {
   font-size: 0.95rem;
-  color: rgba(173, 216, 230, 0.85);
+  color: var(--text-muted);
 }
 
 .dose-note-emphasis {
@@ -438,62 +466,100 @@ button:active {
   font-weight: 700;
 }
 
+
 .panel-guides h1 {
   text-align: center;
   margin-top: 0;
+  letter-spacing: 0.01em;
 }
 
 .guide-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 24px;
-  margin-top: 24px;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 28px;
+  margin-top: 32px;
+}
+
+@media (min-width: 960px) {
+  .guide-grid {
+    grid-template-columns: minmax(260px, 1fr) minmax(420px, 2fr);
+    align-items: stretch;
+  }
 }
 
 .guide-card {
-  background: rgba(0, 0, 0, 0.55);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  border-radius: 14px;
-  padding: 20px;
+  background: var(--surface-soft);
+  border: 1px solid var(--card-border);
+  border-radius: 18px;
+  padding: 24px;
   display: flex;
   flex-direction: column;
-  gap: 16px;
-  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.4);
+  gap: 20px;
+  box-shadow: 0 20px 44px rgba(0, 0, 0, 0.45);
+  min-height: 100%;
 }
 
 .guide-card h2 {
   margin: 0;
   text-align: center;
+  font-size: clamp(1.35rem, 0.8vw + 1.1rem, 1.6rem);
 }
 
 .guide-card h3 {
-  margin-bottom: 8px;
+  margin-bottom: 10px;
 }
 
 .guide-card ul {
   margin: 0;
-  padding-left: 20px;
+  padding-left: 1.2rem;
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 8px;
+  color: var(--text-muted);
+  list-style: disc;
+}
+
+.guide-card-acetaminophen .acetaminophen-safety {
+  margin-top: 4px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  text-align: center;
+}
+
+.acetaminophen-safety ul {
+  list-style-position: inside;
+  list-style: disc;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 8px;
+  max-width: 440px;
+  text-align: left;
+}
+
+.acetaminophen-safety li {
+  color: var(--text-muted);
 }
 
 .guide-subgrid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  gap: 16px;
+  gap: 20px;
 }
 
 .guide-subcard {
-  background: rgba(255, 255, 255, 0.06);
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  border-radius: 12px;
-  padding: 16px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--card-border);
+  border-radius: 16px;
+  padding: 18px;
   display: flex;
   flex-direction: column;
   align-items: center;
   text-align: center;
-  gap: 12px;
+  gap: 14px;
+  box-shadow: 0 16px 36px rgba(0, 0, 0, 0.38);
 }
 
 .visually-hidden {
@@ -513,10 +579,11 @@ button:active {
   flex-direction: column;
   gap: 8px;
   align-items: center;
+  justify-content: center;
 }
 
 .guide-subcard img {
-  max-width: 140px;
+  max-width: 150px;
   width: 100%;
   height: auto;
 }
@@ -529,6 +596,7 @@ button:active {
 .guide-subcard p {
   margin: 0;
   font-size: 0.95rem;
+  color: var(--text-muted);
 }
 
 .guide-return {
@@ -553,46 +621,55 @@ button:active {
 .carousel-track {
   position: relative;
   overflow: hidden;
-  border-radius: 12px;
-  background: rgba(0, 0, 0, 0.5);
+  border-radius: 16px;
+  background: rgba(6, 12, 24, 0.78);
+  border: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .carousel-section.carousel-compact .carousel-track {
-  background: rgba(0, 0, 0, 0.35);
+  background: rgba(6, 12, 24, 0.65);
 }
 
 .carousel-slide {
   display: none;
-  padding: 24px;
+  padding: 28px 24px;
   text-align: center;
+  min-height: 320px;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
 }
 
 .carousel-slide.is-active {
-  display: block;
+  display: flex;
 }
 
 .carousel-slide img {
-  max-width: min(280px, 100%);
-  width: 100%;
-  height: auto;
-  border-radius: 8px;
-  margin-bottom: 12px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
+  width: min(260px, 70%);
+  aspect-ratio: 3 / 4;
+  object-fit: contain;
+  border-radius: 12px;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.45);
+  background: rgba(255, 255, 255, 0.06);
+  padding: 12px;
 }
 
 .carousel-section.carousel-compact .carousel-slide {
-  padding: 20px 16px;
+  min-height: 260px;
+  padding: 24px 16px;
 }
 
 .carousel-section.carousel-compact .carousel-slide img {
-  max-width: min(180px, 100%);
-  margin-inline: auto;
+  width: min(180px, 65%);
+  aspect-ratio: 2 / 3;
 }
 
 .carousel-slide figcaption {
   margin: 0;
   font-size: 0.95rem;
-  line-height: 1.4;
+  line-height: 1.45;
+  color: var(--text-muted);
 }
 
 .carousel-section.carousel-compact .carousel-slide figcaption {
@@ -603,44 +680,53 @@ button:active {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 12px;
+  gap: 16px;
+  margin-top: 12px;
 }
 
 .carousel-controls button {
   width: auto;
-  padding-inline: 16px;
-  font-size: 1.25rem;
-  box-shadow: none;
-  background: rgba(255, 255, 255, 0.12);
+  padding: 10px 18px;
+  font-size: 1.1rem;
+  background: rgba(76, 184, 255, 0.18);
+  border: 1px solid rgba(76, 184, 255, 0.45);
   color: var(--text-light);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.35);
+}
+
+.carousel-controls button:hover {
+  background: rgba(76, 184, 255, 0.3);
 }
 
 .carousel-section.carousel-compact .carousel-controls {
-  gap: 10px;
+  gap: 12px;
 }
 
 .carousel-section.carousel-compact .carousel-controls button {
   padding: 8px 14px;
-  font-size: 1.1rem;
+  font-size: 1rem;
 }
 
 .carousel-dots {
   display: flex;
-  gap: 8px;
+  gap: 10px;
 }
 
 .carousel-dot {
-  width: 10px;
-  height: 10px;
+  width: 12px;
+  height: 12px;
   border-radius: 50%;
-  border: none;
-  background-color: rgba(255, 255, 255, 0.4);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  background-color: rgba(255, 255, 255, 0.2);
   cursor: pointer;
   padding: 0;
+  transition: background-color 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
 }
 
 .carousel-dot.is-active {
-  background-color: rgba(255, 255, 255, 0.85);
+  background-color: var(--primary);
+  border-color: rgba(76, 184, 255, 0.6);
+  transform: scale(1.1);
 }
 
 footer {


### PR DESCRIPTION
## Summary
- restrict the translation overlay to a single Spanish option with updated copy and navigation labeling across pages
- restyle the calculator experience with a refreshed palette, elevated input panels, and modernized action button treatments
- rebalance the medication guides layout so the acetaminophen tips are centered, carousels stay uniform, and the ibuprofen column spans extra width

## Testing
- No automated tests (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cd8dc1bc548329827b307b3d832655