### PR TITLE
Use semantic list structure for translation options

### DIFF
--- a/acetaminophen.html
+++ b/acetaminophen.html
@@ -77,9 +77,11 @@
           cargar el contenido completo en ese idioma.
         </p>
       </div>
-      <div class="translation-options" role="list">
-        <button type="button" class="translation-option" data-translate="es" data-lang-name="Español">Español</button>
-      </div>
+      <ul class="translation-options">
+        <li>
+          <button type="button" class="translation-option" data-translate="es" data-lang-name="Español">Español</button>
+        </li>
+      </ul>
       <p class="translation-status" data-selection-status aria-live="polite"></p>
     </div>
   </div>

--- a/ibuprofen.html
+++ b/ibuprofen.html
@@ -76,9 +76,11 @@
           cargar el contenido completo en ese idioma.
         </p>
       </div>
-      <div class="translation-options" role="list">
-        <button type="button" class="translation-option" data-translate="es" data-lang-name="Español">Español</button>
-      </div>
+      <ul class="translation-options">
+        <li>
+          <button type="button" class="translation-option" data-translate="es" data-lang-name="Español">Español</button>
+        </li>
+      </ul>
       <p class="translation-status" data-selection-status aria-live="polite"></p>
     </div>
   </div>

--- a/index.html
+++ b/index.html
@@ -68,9 +68,11 @@
           cargar el contenido completo en ese idioma.
         </p>
       </div>
-      <div class="translation-options" role="list">
-        <button type="button" class="translation-option" data-translate="es" data-lang-name="Español">Español</button>
-      </div>
+      <ul class="translation-options">
+        <li>
+          <button type="button" class="translation-option" data-translate="es" data-lang-name="Español">Español</button>
+        </li>
+      </ul>
       <p class="translation-status" data-selection-status aria-live="polite"></p>
     </div>
   </div>

--- a/medication-guides.html
+++ b/medication-guides.html
@@ -148,9 +148,11 @@
           cargar el contenido completo en ese idioma.
         </p>
       </div>
-      <div class="translation-options" role="list">
-        <button type="button" class="translation-option" data-translate="es" data-lang-name="Español">Español</button>
-      </div>
+      <ul class="translation-options">
+        <li>
+          <button type="button" class="translation-option" data-translate="es" data-lang-name="Español">Español</button>
+        </li>
+      </ul>
       <p class="translation-status" data-selection-status aria-live="polite"></p>
     </div>
   </div>

--- a/style.css
+++ b/style.css
@@ -365,9 +365,16 @@ button:focus-visible {
 }
 
 .translation-options {
+  list-style: none;
+  margin: 0;
+  padding: 0;
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
   gap: 16px;
+}
+
+.translation-options > li {
+  display: flex;
 }
 
 .translation-option {


### PR DESCRIPTION
## Summary
- wrap translation overlays on each page in a semantic list structure so the buttons are inside list items
- adjust translation option styles to reset list spacing and keep the grid layout intact

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68cd98b4d50c8329bd83df2d61307340