### PR TITLE
Refine ibuprofen guide carousels

### DIFF
--- a/acetaminophen.html
+++ b/acetaminophen.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <nav class="tabs">
-    <a href="index.html">Calculator</a>
+    <a href="index.html">CloseDose</a>
     <a href="acetaminophen.html" class="active">Acetaminophen Guide</a>
     <a href="ibuprofen.html">Ibuprofen Guide</a>
     <button type="button" class="tab-button" data-open-translations aria-haspopup="dialog" aria-expanded="false" aria-label="Open Spanish translation">
@@ -56,7 +56,7 @@
         <li>Contact a healthcare provider for children under 2 months of age with a fever.</li>
       </ul>
       <p>
-        For quick dosing, return to the <a href="index.html">calculator</a> and enter your child's
+        For quick dosing, return to <a href="index.html">CloseDose</a> and enter your child's
         age and weight.
       </p>
     </section>

--- a/ibuprofen.html
+++ b/ibuprofen.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <nav class="tabs">
-    <a href="index.html">Calculator</a>
+    <a href="index.html">CloseDose</a>
     <a href="acetaminophen.html">Acetaminophen Guide</a>
     <a href="ibuprofen.html" class="active">Ibuprofen Guide</a>
     <button type="button" class="tab-button" data-open-translations aria-haspopup="dialog" aria-expanded="false" aria-label="Open Spanish translation">
@@ -55,7 +55,7 @@
         <li>Spacing between doses should be at least 6 hours.</li>
       </ul>
       <p>
-        Need to double-check a dose? Visit the <a href="index.html">calculator</a> for a personalized
+        Need to double-check a dose? Visit <a href="index.html">CloseDose</a> for a personalized
         recommendation.
       </p>
     </section>

--- a/index.html
+++ b/index.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>ChillPill | Pediatric Antipyretic Dose Calculator</title>
+  <title>CloseDose | Pediatric Antipyretic Dose Calculator</title>
   <link rel="stylesheet" href="./style.css" />
 </head>
 <body>
   <nav class="tabs">
-    <a href="index.html" class="active">Calculator</a>
+    <a href="index.html" class="active">CloseDose</a>
     <a href="medication-guides.html">Medication Guides</a>
     <button type="button" class="tab-button" data-open-translations aria-haspopup="dialog" aria-expanded="false" aria-label="Open Spanish translation">
       Spanish
@@ -21,7 +21,7 @@
     <section id="calculator" class="panel panel-calculator" aria-labelledby="calculator-heading">
 
       <header class="calculator-header">
-        <h1 id="calculator-heading">ChillPill</h1>
+        <h1 id="calculator-heading">CloseDose</h1>
         <p class="calculator-subtitle">Pediatric Antipyretic Dose Calculator</p>
       </header>
       <div class="field">

--- a/medication-guides.html
+++ b/medication-guides.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <nav class="tabs">
-    <a href="index.html">Calculator</a>
+    <a href="index.html">CloseDose</a>
     <a href="medication-guides.html" class="active">Medication Guides</a>
     <button type="button" class="tab-button" data-open-translations aria-haspopup="dialog" aria-expanded="false" aria-label="Open Spanish translation">
       Spanish
@@ -30,15 +30,19 @@
             <div class="carousel-track">
               <figure class="carousel-slide">
                 <img src="images/Acetaminophen/Tylenol acetaminophen iso.png" alt="Tylenol" />
+                <figcaption>Tylenol<sup>&reg;</sup> Children's Oral Suspension (160 mg per 5 mL)</figcaption>
               </figure>
               <figure class="carousel-slide">
                 <img src="images/Acetaminophen/amazon acetaminophen iso.png" alt="Amazon" />
+                <figcaption>Amazon Basics Children's Acetaminophen (160 mg per 5 mL)</figcaption>
               </figure>
               <figure class="carousel-slide">
                 <img src="images/Acetaminophen/Target acetaminophen iso.png" alt="Target" />
+                <figcaption>up &amp; up<sup>&reg;</sup> Children's Acetaminophen (160 mg per 5 mL)</figcaption>
               </figure>
               <figure class="carousel-slide">
-                <img src="images/Acetaminophen/Equate acetaminophen iso.png" alt="Walmart"/>
+                <img src="images/Acetaminophen/Equate acetaminophen iso.png" alt="Walmart" />
+                <figcaption>Equate<sup>&reg;</sup> Children's Acetaminophen (160 mg per 5 mL)</figcaption>
               </figure>
             </div>
             <div class="carousel-controls">
@@ -52,74 +56,79 @@
             <ul>
               <li>Do not exceed 6 doses in 24 hours.</li>
               <li>&lt;6 months old: dose every 4 hours as needed.</li>
-              <li>&gt;6 months old: dose every 6 hours as needed; may consider alternating dosing with ibuprofen (every 6 hour dosing) to allow medication to be given every 3 hours. </li>
+              <li>&gt;6 months old: dose every 6 hours as needed; may consider alternating dosing with ibuprofen (every 6 hour dosing) to allow medication to be given every 3 hours.</li>
               <li>Contact a healthcare provider for children under 2 months of age with a fever or for persistent fever &gt;3 days.</li>
               <li>Keep a log of medication given, time, and dose to avoid accidental repeat dosing.</li>
             </ul>
           </div>
         </article>
         <article class="guide-card guide-card-ibuprofen">
-          <h2>Ibuprofen</h2>
-          <div class="guide-subgrid">
-            <section class="guide-subcard">
-              <h3>Children's Ibuprofen (100 mg / 5 mL)</h3>
-              <section class="carousel-section carousel-compact" data-carousel>
-                <h4 class="visually-hidden">Children's ibuprofen product labels</h4>
-                <div class="carousel-track">
-                  <figure class="carousel-slide">
-                    <img src="images/Ibuprofen/Children/Motrin Children ibuprofen iso.png" alt="Motrin" />
-                  </figure>
-                  <figure class="carousel-slide">
-                    <img src="images/Ibuprofen/Children/Advil Children Ibuprofen iso.png" alt="Advil" />
-                  </figure>
-                  <figure class="carousel-slide">
-                    <img src="images/Ibuprofen/Children/Amazon Children ibuprofen iso.png" alt="Amazon" />
-                  </figure>
-                  <figure class="carousel-slide">
-                    <img src="images/Ibuprofen/Children/Target Children ibuprofen iso.png" alt="Target" />
-                  </figure>
-                  <figure class="carousel-slide">
-                    <img src="images/Ibuprofen/Children/Equate Children ibuprofen iso.png" alt="Equate" />
-                  </figure>
-                </div>
-                <div class="carousel-controls">
-                  <button type="button" data-carousel-prev aria-label="Show previous children's ibuprofen product">&#8592;</button>
-                  <div class="carousel-dots" aria-hidden="true"></div>
-                  <button type="button" data-carousel-next aria-label="Show next children's ibuprofen product">&#8594;</button>
-                </div>
-              </section>
-              <p>Standard children's suspension dosed using an oral syringe or medicine cup. Verify strength before dosing.</p>
-            </section>
-            <section class="guide-subcard">
-              <h3>Infant Drops (50 mg / 1.25 mL)</h3>
-              <section class="carousel-section carousel-compact" data-carousel>
-                <h4 class="visually-hidden">Infant ibuprofen product labels</h4>
-                <div class="carousel-track">
-                  <figure class="carousel-slide">
-                    <img src="images/Ibuprofen/Infants/Motrin Infant ibuprofen iso.png" alt="Motrin" />
-                  </figure>
-                  <figure class="carousel-slide">
-                    <img src="images/Ibuprofen/Infants/Advil Infant Ibuprofen iso.png" alt="Infants' Advil concentrated ibuprofen drops 50 mg per 1.25 mL label" />
-                  </figure>
-                  <figure class="carousel-slide">
-                    <img src="images/Ibuprofen/Infants/Amazon Infant ibuprofen iso.png" alt="Amazon" />
-                  </figure>
-                  <figure class="carousel-slide">
-                    <img src="images/Ibuprofen/Infants/Target Infant Ibuprofen iso.png" alt="Target" />
-                  </figure>
-                  <figure class="carousel-slide">
-                    <img src="images/Ibuprofen/Infants/Equate Infant Ibuprofen iso.png" alt="Equate" />
-                  </figure>
-                </div>
-                <div class="carousel-controls">
-                  <button type="button" data-carousel-prev aria-label="Show previous infant ibuprofen product">&#8592;</button>
-                  <div class="carousel-dots" aria-hidden="true"></div>
-                  <button type="button" data-carousel-next aria-label="Show next infant ibuprofen product">&#8594;</button>
-                </div>
-              </section>
-              <p>Highly concentrated infant drops dosed with the included dropper.</p>
-            </section>
-          </div>
+          <h2>Children's Ibuprofen</h2>
+          <section class="carousel-section" data-carousel>
+            <h3>Children's Ibuprofen (100 mg / 5 mL)</h3>
+            <div class="carousel-track">
+              <figure class="carousel-slide">
+                <img src="images/Ibuprofen/Children/Motrin Children ibuprofen iso.png" alt="Motrin" />
+                <figcaption>Motrin<sup>&reg;</sup> Children's Suspension (100 mg per 5 mL)</figcaption>
+              </figure>
+              <figure class="carousel-slide">
+                <img src="images/Ibuprofen/Children/Advil Children Ibuprofen iso.png" alt="Advil" />
+                <figcaption>Advil<sup>&reg;</sup> Children's Suspension (100 mg per 5 mL)</figcaption>
+              </figure>
+              <figure class="carousel-slide">
+                <img src="images/Ibuprofen/Children/Amazon Children ibuprofen iso.png" alt="Amazon" />
+                <figcaption>Amazon Basics Children's Ibuprofen (100 mg per 5 mL)</figcaption>
+              </figure>
+              <figure class="carousel-slide">
+                <img src="images/Ibuprofen/Children/Target Children ibuprofen iso.png" alt="Target" />
+                <figcaption>up &amp; up<sup>&reg;</sup> Children's Ibuprofen (100 mg per 5 mL)</figcaption>
+              </figure>
+              <figure class="carousel-slide">
+                <img src="images/Ibuprofen/Children/Equate Children ibuprofen iso.png" alt="Equate" />
+                <figcaption>Equate<sup>&reg;</sup> Children's Ibuprofen (100 mg per 5 mL)</figcaption>
+              </figure>
+            </div>
+            <div class="carousel-controls">
+              <button type="button" data-carousel-prev aria-label="Show previous children's ibuprofen product">&#8592;</button>
+              <div class="carousel-dots" aria-hidden="true"></div>
+              <button type="button" data-carousel-next aria-label="Show next children's ibuprofen product">&#8594;</button>
+            </div>
+          </section>
+          <p>Standard children's suspension dosed using an oral syringe or medicine cup. Verify strength before dosing.</p>
+        </article>
+        <article class="guide-card guide-card-ibuprofen">
+          <h2>Infant Ibuprofen</h2>
+          <section class="carousel-section" data-carousel>
+            <h3>Infant Drops (50 mg / 1.25 mL)</h3>
+            <div class="carousel-track">
+              <figure class="carousel-slide">
+                <img src="images/Ibuprofen/Infants/Motrin Infant ibuprofen iso.png" alt="Motrin" />
+                <figcaption>Infant's Motrin<sup>&reg;</sup> Concentrated Drops (50 mg per 1.25 mL)</figcaption>
+              </figure>
+              <figure class="carousel-slide">
+                <img src="images/Ibuprofen/Infants/Advil Infant Ibuprofen iso.png" alt="Infants' Advil concentrated ibuprofen drops 50 mg per 1.25 mL label" />
+                <figcaption>Infants' Advil<sup>&reg;</sup> Concentrated Drops (50 mg per 1.25 mL)</figcaption>
+              </figure>
+              <figure class="carousel-slide">
+                <img src="images/Ibuprofen/Infants/Amazon Infant ibuprofen iso.png" alt="Amazon" />
+                <figcaption>Amazon Basics Infant Ibuprofen (50 mg per 1.25 mL)</figcaption>
+              </figure>
+              <figure class="carousel-slide">
+                <img src="images/Ibuprofen/Infants/Target Infant Ibuprofen iso.png" alt="Target" />
+                <figcaption>up &amp; up<sup>&reg;</sup> Infant Ibuprofen (50 mg per 1.25 mL)</figcaption>
+              </figure>
+              <figure class="carousel-slide">
+                <img src="images/Ibuprofen/Infants/Equate Infant Ibuprofen iso.png" alt="Equate" />
+                <figcaption>Equate<sup>&reg;</sup> Infant Ibuprofen (50 mg per 1.25 mL)</figcaption>
+              </figure>
+            </div>
+            <div class="carousel-controls">
+              <button type="button" data-carousel-prev aria-label="Show previous infant ibuprofen product">&#8592;</button>
+              <div class="carousel-dots" aria-hidden="true"></div>
+              <button type="button" data-carousel-next aria-label="Show next infant ibuprofen product">&#8594;</button>
+            </div>
+          </section>
+          <p>Highly concentrated infant drops dosed with the included dropper.</p>
           <h3>Safety Tips</h3>
           <ul>
             <li>Do not use in infants under 6 months unless directed by a doctor.</li>
@@ -129,7 +138,7 @@
           </ul>
         </article>
       </div>
-      <p class="guide-return">Need a quick calculation? Visit the <a href="index.html">dose calculator</a>.</p>
+      <p class="guide-return">Need a quick calculation? Visit the <a href="index.html">CloseDose calculator</a>.</p>
     </section>
   </main>
 

--- a/script.js
+++ b/script.js
@@ -92,6 +92,7 @@ function calculateDose() {
           ? ' Weight-based dose was limited to this maximum. Consider discussing dosing with your pediatrician.'
           : ''
       }</p>
+      <p class="dose-note dose-note-emphasis">Ibuprofen is not recommended for infants under six months. Consult your pediatrician before using ibuprofen for this age group.</p>
     `;
   } else if (age === '6+') {
     const ACETA_MAX_SINGLE_DOSE_MG = 1000;

--- a/style.css
+++ b/style.css
@@ -21,7 +21,13 @@ body {
   font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
   color: var(--text-light);
   background-color: #050505;
-  background-image: linear-gradient(160deg, rgba(0, 0, 0, 0.85), rgba(24, 24, 24, 0.95));
+  background-image:
+    linear-gradient(160deg, rgba(0, 0, 0, 0.85), rgba(24, 24, 24, 0.95)),
+    url('./images/bg2.jpg');
+  background-size: auto, cover;
+  background-repeat: no-repeat, no-repeat;
+  background-position: center, center;
+  background-attachment: fixed;
   display: flex;
   flex-direction: column;
   line-height: 1.6;
@@ -440,16 +446,10 @@ button:focus-visible {
 
 .guide-grid {
   display: grid;
-  grid-template-columns: minmax(0, 1fr);
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
   gap: 28px;
   margin-top: 32px;
-}
-
-@media (min-width: 960px) {
-  .guide-grid {
-    grid-template-columns: minmax(260px, 1fr) minmax(420px, 2fr);
-    align-items: stretch;
-  }
+  align-items: stretch;
 }
 
 .guide-card {
@@ -508,25 +508,6 @@ button:focus-visible {
   color: var(--text-muted);
 }
 
-.guide-subgrid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  gap: 20px;
-}
-
-.guide-subcard {
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid var(--card-border);
-  border-radius: 16px;
-  padding: 18px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  text-align: center;
-  gap: 14px;
-  box-shadow: 0 16px 36px rgba(0, 0, 0, 0.38);
-}
-
 .visually-hidden {
   position: absolute;
   width: 1px;
@@ -536,32 +517,6 @@ button:focus-visible {
   overflow: hidden;
   clip: rect(0, 0, 0, 0);
   border: 0;
-}
-
-.guide-subcard figure {
-  margin: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  align-items: center;
-  justify-content: center;
-}
-
-.guide-subcard img {
-  max-width: 150px;
-  width: 100%;
-  height: auto;
-}
-
-.guide-subcard figcaption {
-  font-size: 0.95rem;
-  color: rgba(255, 255, 255, 0.85);
-}
-
-.guide-subcard p {
-  margin: 0;
-  font-size: 0.95rem;
-  color: var(--text-muted);
 }
 
 .guide-return {
@@ -578,21 +533,12 @@ button:focus-visible {
   gap: 16px;
 }
 
-.carousel-section.carousel-compact {
-  width: 100%;
-  gap: 12px;
-}
-
 .carousel-track {
   position: relative;
   overflow: hidden;
   border-radius: 16px;
   background: rgba(6, 12, 24, 0.78);
   border: 1px solid rgba(255, 255, 255, 0.08);
-}
-
-.carousel-section.carousel-compact .carousel-track {
-  background: rgba(6, 12, 24, 0.65);
 }
 
 .carousel-slide {
@@ -620,25 +566,11 @@ button:focus-visible {
   padding: 12px;
 }
 
-.carousel-section.carousel-compact .carousel-slide {
-  min-height: 260px;
-  padding: 24px 16px;
-}
-
-.carousel-section.carousel-compact .carousel-slide img {
-  width: min(180px, 65%);
-  aspect-ratio: 2 / 3;
-}
-
 .carousel-slide figcaption {
   margin: 0;
   font-size: 0.95rem;
   line-height: 1.45;
   color: var(--text-muted);
-}
-
-.carousel-section.carousel-compact .carousel-slide figcaption {
-  font-size: 0.9rem;
 }
 
 .carousel-controls {
@@ -663,14 +595,6 @@ button:focus-visible {
   background: rgba(200, 200, 200, 0.32);
 }
 
-.carousel-section.carousel-compact .carousel-controls {
-  gap: 12px;
-}
-
-.carousel-section.carousel-compact .carousel-controls button {
-  padding: 8px 14px;
-  font-size: 1rem;
-}
 
 .carousel-dots {
   display: flex;
@@ -699,12 +623,6 @@ footer {
   text-align: center;
   background-color: rgba(0, 0, 0, 0.6);
   font-size: 0.9rem;
-}
-
-@media (min-width: 768px) {
-  .guide-subgrid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- restructure the medication guides grid so acetaminophen, children's ibuprofen, and infant ibuprofen each render as full-width carousel columns
- add detailed figcaptions to ibuprofen and acetaminophen carousel slides so the ibuprofen carousels behave like the acetaminophen carousel
- simplify carousel styling by removing the compact variant and widening each column for better large-screen layout

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd98b89d008329a30cf7b7fa6a061f