### PR TITLE
Refine medication carousel layout

### DIFF
--- a/medication-guides.html
+++ b/medication-guides.html
@@ -65,7 +65,6 @@
           </div>
         </article>
         <article class="guide-card guide-card-ibuprofen">
-           <div class="guide-subgrid">
           <h2>Children's Ibuprofen</h2>
           <section class="carousel-section" data-carousel>
             <h3>Children's Ibuprofen (100 mg / 5 mL)</h3>
@@ -132,70 +131,9 @@
             </div>
           </section>
           <p>Highly concentrated infant drops dosed with the included dropper.</p>
-          <h2>Ibuprofen</h2>
-          <div class="guide-subgrid">
-            <section class="guide-subcard">
-              <h3>Children's Ibuprofen (100 mg / 5 mL)</h3>
-              <section class="carousel-section carousel-compact" data-carousel>
-                <h4 class="visually-hidden">Children's ibuprofen product labels</h4>
-                <div class="carousel-track">
-                  <figure class="carousel-slide">
-                    <img src="images/Ibuprofen/Children/Motrin Children ibuprofen iso.png" alt="Motrin" />
-                  </figure>
-                  <figure class="carousel-slide">
-                    <img src="images/Ibuprofen/Children/Advil Children Ibuprofen iso.png" alt="Advil" />
-                  </figure>
-                  <figure class="carousel-slide">
-                    <img src="images/Ibuprofen/Children/Amazon Children ibuprofen iso.png" alt="Amazon" />
-                  </figure>
-                  <figure class="carousel-slide">
-                    <img src="images/Ibuprofen/Children/Target Children ibuprofen iso.png" alt="Target" />
-                  </figure>
-                  <figure class="carousel-slide">
-                    <img src="images/Ibuprofen/Children/Equate Children ibuprofen iso.png" alt="Equate" />
-                  </figure>
-                </div>
-                <div class="carousel-controls">
-                  <button type="button" data-carousel-prev aria-label="Show previous children's ibuprofen product">&#8592;</button>
-                  <div class="carousel-dots" aria-hidden="true"></div>
-                  <button type="button" data-carousel-next aria-label="Show next children's ibuprofen product">&#8594;</button>
-                </div>
-              </section>
-              <p>Standard children's suspension dosed using an oral syringe or medicine cup. Verify strength before dosing.</p>
-            </section>
-            <section class="guide-subcard">
-              <h3>Infant Drops (50 mg / 1.25 mL)</h3>
-              <section class="carousel-section carousel-compact" data-carousel>
-                <h4 class="visually-hidden">Infant ibuprofen product labels</h4>
-                <div class="carousel-track">
-                  <figure class="carousel-slide">
-                    <img src="images/Ibuprofen/Infants/Motrin Infant ibuprofen iso.png" alt="Motrin" />
-                  </figure>
-                  <figure class="carousel-slide">
-                    <img src="images/Ibuprofen/Infants/Advil Infant Ibuprofen iso.png" alt="Advil" />
-                  </figure>
-                  <figure class="carousel-slide">
-                    <img src="images/Ibuprofen/Infants/Amazon Infant ibuprofen iso.png" alt="Amazon" />
-                  </figure>
-                  <figure class="carousel-slide">
-                    <img src="images/Ibuprofen/Infants/Target Infant Ibuprofen iso.png" alt="Target" />
-                  </figure>
-                  <figure class="carousel-slide">
-                    <img src="images/Ibuprofen/Infants/Equate Infant ibuprofen iso.png" alt="Equate" />
-                  </figure>
-                </div>
-                <div class="carousel-controls">
-                  <button type="button" data-carousel-prev aria-label="Show previous infant ibuprofen product">&#8592;</button>
-                  <div class="carousel-dots" aria-hidden="true"></div>
-                  <button type="button" data-carousel-next aria-label="Show next infant ibuprofen product">&#8594;</button>
-                </div>
-              </section>
-              <p>Highly concentrated infant drops dosed with the included dropper.</p>
-            </section>
-          </div>
           <h3>Safety Tips</h3>
           <ul>
-            <li>Do not give to infants <6 months unless directed by a doctor.</li>
+            <li>Do not give to infants &lt;6 months unless directed by a doctor.</li>
             <li>Allow at least 6 hours between doses.</li>
             <li>Do not exceed 4 doses in 24 hours.</li>
             <li>Give with food or milk to lessen stomach upset.</li>

--- a/style.css
+++ b/style.css
@@ -138,7 +138,7 @@ body {
 }
 
 .panel-guides {
-  width: min(980px, 100%);
+  width: min(1100px, 100%);
 }
 
 #message {
@@ -453,8 +453,8 @@ button:focus-visible {
 
 .guide-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-  gap: 28px;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 32px;
   margin-top: 32px;
   align-items: stretch;
 }
@@ -543,20 +543,20 @@ button:focus-visible {
 .carousel-track {
   position: relative;
   overflow: hidden;
-  border-radius: 16px;
-  background: rgba(6, 12, 24, 0.78);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 18px;
+  background: rgba(6, 12, 24, 0.82);
+  border: 1px solid rgba(255, 255, 255, 0.1);
 }
 
 .carousel-slide {
   display: none;
-  padding: 28px 24px;
+  padding: 36px 28px;
   text-align: center;
-  min-height: 320px;
+  min-height: 360px;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 16px;
+  gap: 20px;
 }
 
 .carousel-slide.is-active {
@@ -564,13 +564,14 @@ button:focus-visible {
 }
 
 .carousel-slide img {
-  width: min(260px, 70%);
+  width: min(340px, 85%);
+  max-height: 420px;
   aspect-ratio: 3 / 4;
   object-fit: contain;
-  border-radius: 12px;
-  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.45);
-  background: rgba(255, 255, 255, 0.06);
-  padding: 12px;
+  border-radius: 14px;
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.5);
+  background: rgba(255, 255, 255, 0.08);
+  padding: 16px;
 }
 
 .carousel-slide figcaption {
@@ -639,5 +640,20 @@ footer {
 
   .tabs {
     justify-content: center;
+  }
+
+  .guide-grid {
+    grid-template-columns: 1fr;
+    gap: 24px;
+  }
+
+  .carousel-slide {
+    padding: 28px 20px;
+    min-height: 320px;
+  }
+
+  .carousel-slide img {
+    width: min(280px, 90%);
+    max-height: 340px;
   }
 }


### PR DESCRIPTION
## Summary
- reorganized the medication guides grid so the three product carousels (children's acetaminophen, children's ibuprofen, infant ibuprofen) each occupy their own column with single-slide behavior
- removed redundant infant ibuprofen galleries, preserved safety guidance, and widened the guides panel to give the imagery more breathing room
- enlarged carousel artwork and tuned responsive styles to maximize product visibility while keeping the layout mobile friendly

## Testing
- not run (static content changes)


------
https://chatgpt.com/codex/tasks/task_e_68ce4f96aa708329b8beb127f8034976