### PR TITLE
Add branded header and enhance medication guide layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,25 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="color-scheme" content="dark light" />
+  <meta
+    name="description"
+    content="CloseDose helps caregivers calculate safe pediatric acetaminophen and ibuprofen doses with easy medication guides."
+  />
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="CloseDose | Pediatric Antipyretic Dose Calculator" />
+  <meta
+    property="og:description"
+    content="Plan safe acetaminophen and ibuprofen dosing with CloseDose's pediatric calculator and medication guidance."
+  />
+  <meta property="og:image" content="images/og.png" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="CloseDose | Pediatric Antipyretic Dose Calculator" />
+  <meta
+    name="twitter:description"
+    content="Plan safe acetaminophen and ibuprofen dosing with CloseDose's pediatric calculator and medication guidance."
+  />
+  <meta name="twitter:image" content="images/og.png" />
   <title>CloseDose | Pediatric Antipyretic Dose Calculator</title>
   <link rel="stylesheet" href="./style.css" />
 </head>
@@ -14,6 +33,17 @@
       Spanish
     </button>
   </nav>
+
+  <header class="brand-header">
+    <picture class="brand-logo">
+      <source srcset="images/logo/CloseDose Logo_2048-transparent.png" media="(prefers-color-scheme: dark)" />
+      <img src="images/logo/CloseDose Logo_Black_2048_Transparent.png" alt="CloseDose logo" />
+    </picture>
+    <h1 class="brand-title">
+      <span class="brand-title-dark">Close</span>
+      <span class="brand-title-teal">Dose</span>
+    </h1>
+  </header>
 
   <main class="page">
     <div id="message" role="alert" aria-live="polite" hidden></div>

--- a/medication-guides.html
+++ b/medication-guides.html
@@ -3,6 +3,25 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="color-scheme" content="dark light" />
+  <meta
+    name="description"
+    content="Browse CloseDose medication guides for pediatric acetaminophen and ibuprofen products, concentrations, and safety tips."
+  />
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="CloseDose | Medication Guides" />
+  <meta
+    property="og:description"
+    content="Explore pediatric acetaminophen and ibuprofen product concentrations with CloseDose medication guides."
+  />
+  <meta property="og:image" content="images/og.png" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="CloseDose | Medication Guides" />
+  <meta
+    name="twitter:description"
+    content="Explore pediatric acetaminophen and ibuprofen product concentrations with CloseDose medication guides."
+  />
+  <meta name="twitter:image" content="images/og.png" />
   <title>Medication Guides</title>
   <link rel="stylesheet" href="./style.css" />
 </head>
@@ -15,6 +34,17 @@
     </button>
   </nav>
 
+  <header class="brand-header">
+    <picture class="brand-logo">
+      <source srcset="images/logo/CloseDose Logo_2048-transparent.png" media="(prefers-color-scheme: dark)" />
+      <img src="images/logo/CloseDose Logo_Black_2048_Transparent.png" alt="CloseDose logo" />
+    </picture>
+    <h1 class="brand-title">
+      <span class="brand-title-dark">Close</span>
+      <span class="brand-title-teal">Dose</span>
+    </h1>
+  </header>
+
   <main class="page">
     <section class="panel panel-guides">
       <h1>Fever/Pain Medication Guides</h1>
@@ -26,23 +56,38 @@
         <article class="guide-card guide-card-acetaminophen">
           <h2>Acetaminophen</h2>
           <section class="carousel-section" data-carousel>
-            <h3>Children's Acetaminophen (160 mg / 5 mL)</h3>
+            <h3>
+              Children's Acetaminophen
+              <span class="medication-concentration">160 mg / 5 mL</span>
+            </h3>
             <div class="carousel-track">
               <figure class="carousel-slide">
                 <img src="images/Acetaminophen/Tylenol acetaminophen iso.png" alt="Tylenol" />
-                <figcaption>Tylenol<sup>&reg;</sup> Children's Oral Suspension (160 mg per 5 mL)</figcaption>
+                <figcaption>
+                  Tylenol<sup>&reg;</sup> Children's Oral Suspension
+                  <span class="medication-concentration">160 mg per 5 mL</span>
+                </figcaption>
               </figure>
               <figure class="carousel-slide">
                 <img src="images/Acetaminophen/amazon acetaminophen iso.png" alt="Amazon" />
-                <figcaption>Amazon Basics Children's Acetaminophen (160 mg per 5 mL)</figcaption>
+                <figcaption>
+                  Amazon Basics Children's Acetaminophen
+                  <span class="medication-concentration">160 mg per 5 mL</span>
+                </figcaption>
               </figure>
               <figure class="carousel-slide">
                 <img src="images/Acetaminophen/Target acetaminophen iso.png" alt="Target" />
-                <figcaption>up &amp; up<sup>&reg;</sup> Children's Acetaminophen (160 mg per 5 mL)</figcaption>
+                <figcaption>
+                  up &amp; up<sup>&reg;</sup> Children's Acetaminophen
+                  <span class="medication-concentration">160 mg per 5 mL</span>
+                </figcaption>
               </figure>
               <figure class="carousel-slide">
                 <img src="images/Acetaminophen/Equate acetaminophen iso.png" alt="Walmart" />
-                <figcaption>Equate<sup>&reg;</sup> Children's Acetaminophen (160 mg per 5 mL)</figcaption>
+                <figcaption>
+                  Equate<sup>&reg;</sup> Children's Acetaminophen
+                  <span class="medication-concentration">160 mg per 5 mL</span>
+                </figcaption>
               </figure>
             </div>
             <div class="carousel-controls">
@@ -67,27 +112,45 @@
         <article class="guide-card guide-card-ibuprofen">
           <h2>Children's Ibuprofen</h2>
           <section class="carousel-section" data-carousel>
-            <h3>Children's Ibuprofen (100 mg / 5 mL)</h3>
+            <h3>
+              Children's Ibuprofen
+              <span class="medication-concentration">100 mg / 5 mL</span>
+            </h3>
             <div class="carousel-track">
               <figure class="carousel-slide">
                 <img src="images/Ibuprofen/Children/Motrin Children ibuprofen iso.png" alt="Motrin" />
-                <figcaption>Motrin<sup>&reg;</sup> Children's Suspension (100 mg per 5 mL)</figcaption>
+                <figcaption>
+                  Motrin<sup>&reg;</sup> Children's Suspension
+                  <span class="medication-concentration">100 mg per 5 mL</span>
+                </figcaption>
               </figure>
               <figure class="carousel-slide">
                 <img src="images/Ibuprofen/Children/Advil Children Ibuprofen iso.png" alt="Advil" />
-                <figcaption>Advil<sup>&reg;</sup> Children's Suspension (100 mg per 5 mL)</figcaption>
+                <figcaption>
+                  Advil<sup>&reg;</sup> Children's Suspension
+                  <span class="medication-concentration">100 mg per 5 mL</span>
+                </figcaption>
               </figure>
               <figure class="carousel-slide">
                 <img src="images/Ibuprofen/Children/Amazon Children ibuprofen iso.png" alt="Amazon" />
-                <figcaption>Amazon Basics Children's Ibuprofen (100 mg per 5 mL)</figcaption>
+                <figcaption>
+                  Amazon Basics Children's Ibuprofen
+                  <span class="medication-concentration">100 mg per 5 mL</span>
+                </figcaption>
               </figure>
               <figure class="carousel-slide">
                 <img src="images/Ibuprofen/Children/Target Children ibuprofen iso.png" alt="Target" />
-                <figcaption>up &amp; up<sup>&reg;</sup> Children's Ibuprofen (100 mg per 5 mL)</figcaption>
+                <figcaption>
+                  up &amp; up<sup>&reg;</sup> Children's Ibuprofen
+                  <span class="medication-concentration">100 mg per 5 mL</span>
+                </figcaption>
               </figure>
               <figure class="carousel-slide">
                 <img src="images/Ibuprofen/Children/Equate Children ibuprofen iso.png" alt="Equate" />
-                <figcaption>Equate<sup>&reg;</sup> Children's Ibuprofen (100 mg per 5 mL)</figcaption>
+                <figcaption>
+                  Equate<sup>&reg;</sup> Children's Ibuprofen
+                  <span class="medication-concentration">100 mg per 5 mL</span>
+                </figcaption>
               </figure>
             </div>
             <div class="carousel-controls">
@@ -101,27 +164,45 @@
         <article class="guide-card guide-card-ibuprofen">
           <h2>Infant Ibuprofen</h2>
           <section class="carousel-section" data-carousel>
-            <h3>Infant Drops (50 mg / 1.25 mL)</h3>
+            <h3>
+              Infant Drops
+              <span class="medication-concentration">50 mg / 1.25 mL</span>
+            </h3>
             <div class="carousel-track">
               <figure class="carousel-slide">
                 <img src="images/Ibuprofen/Infants/Motrin Infant ibuprofen iso.png" alt="Motrin" />
-                <figcaption>Infant's Motrin<sup>&reg;</sup> Concentrated Drops (50 mg per 1.25 mL)</figcaption>
+                <figcaption>
+                  Infant's Motrin<sup>&reg;</sup> Concentrated Drops
+                  <span class="medication-concentration">50 mg per 1.25 mL</span>
+                </figcaption>
               </figure>
               <figure class="carousel-slide">
                 <img src="images/Ibuprofen/Infants/Advil Infant Ibuprofen iso.png" alt="Infants' Advil concentrated ibuprofen drops 50 mg per 1.25 mL label" />
-                <figcaption>Infants' Advil<sup>&reg;</sup> Concentrated Drops (50 mg per 1.25 mL)</figcaption>
+                <figcaption>
+                  Infants' Advil<sup>&reg;</sup> Concentrated Drops
+                  <span class="medication-concentration">50 mg per 1.25 mL</span>
+                </figcaption>
               </figure>
               <figure class="carousel-slide">
                 <img src="images/Ibuprofen/Infants/Amazon Infant ibuprofen iso.png" alt="Amazon" />
-                <figcaption>Amazon Basics Infant Ibuprofen (50 mg per 1.25 mL)</figcaption>
+                <figcaption>
+                  Amazon Basics Infant Ibuprofen
+                  <span class="medication-concentration">50 mg per 1.25 mL</span>
+                </figcaption>
               </figure>
               <figure class="carousel-slide">
                 <img src="images/Ibuprofen/Infants/Target Infant Ibuprofen iso.png" alt="Target" />
-                <figcaption>up &amp; up<sup>&reg;</sup> Infant Ibuprofen (50 mg per 1.25 mL)</figcaption>
+                <figcaption>
+                  up &amp; up<sup>&reg;</sup> Infant Ibuprofen
+                  <span class="medication-concentration">50 mg per 1.25 mL</span>
+                </figcaption>
               </figure>
               <figure class="carousel-slide">
                 <img src="images/Ibuprofen/Infants/Equate Infant Ibuprofen iso.png" alt="Equate" />
-                <figcaption>Equate<sup>&reg;</sup> Infant Ibuprofen (50 mg per 1.25 mL)</figcaption>
+                <figcaption>
+                  Equate<sup>&reg;</sup> Infant Ibuprofen
+                  <span class="medication-concentration">50 mg per 1.25 mL</span>
+                </figcaption>
               </figure>
             </div>
             <div class="carousel-controls">

--- a/style.css
+++ b/style.css
@@ -11,6 +11,42 @@
   --text-muted: rgba(200, 200, 200, 0.75);
 }
 
+@media (prefers-color-scheme: light) {
+  :root {
+    --overlay: rgba(240, 247, 252, 0.9);
+    --surface: rgba(255, 255, 255, 0.94);
+    --surface-soft: rgba(235, 244, 249, 0.94);
+    --card-border: rgba(16, 68, 110, 0.16);
+    --glow: rgba(6, 156, 180, 0.2);
+    --primary: #0f2535;
+    --primary-strong: #081c29;
+    --text-light: #0b2136;
+    --text-muted: rgba(15, 46, 68, 0.7);
+  }
+
+  body {
+    background-color: #f2f7fb;
+    background-image:
+      linear-gradient(160deg, rgba(255, 255, 255, 0.9), rgba(205, 232, 244, 0.92)),
+      url('./images/light bg.png');
+    color: var(--text-light);
+  }
+
+  .brand-header {
+    background: linear-gradient(120deg, rgba(255, 255, 255, 0.92), rgba(219, 239, 247, 0.85));
+    border: 1px solid rgba(12, 44, 72, 0.12);
+    box-shadow: 0 18px 36px rgba(13, 52, 82, 0.18);
+  }
+
+  .brand-title-dark {
+    color: #0a1d2b;
+  }
+
+  .brand-title-teal {
+    color: #0d8f8a;
+  }
+}
+
 * {
   box-sizing: border-box;
 }
@@ -31,6 +67,56 @@ body {
   display: flex;
   flex-direction: column;
   line-height: 1.6;
+}
+
+.brand-header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+  margin: 12px auto 0;
+  padding: 18px 28px;
+  width: min(780px, calc(100% - 32px));
+  border-radius: 28px;
+  background: linear-gradient(120deg, rgba(255, 255, 255, 0.18), rgba(12, 26, 42, 0.78));
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(18px);
+  flex-wrap: wrap;
+  text-align: center;
+}
+
+.brand-logo {
+  display: block;
+  width: clamp(72px, 10vw, 108px);
+}
+
+.brand-logo img {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.brand-title {
+  margin: 0;
+  font-family: 'TT Norms', 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  font-size: clamp(1.8rem, 2.4vw + 1.4rem, 2.8rem);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  display: flex;
+  gap: 0.45ch;
+  align-items: flex-end;
+}
+
+.brand-title-dark {
+  color: #102132;
+}
+
+.brand-title-teal {
+  color: #16e0d5;
+  text-decoration: underline;
+  text-decoration-thickness: 0.18em;
+  text-underline-offset: 0.22em;
 }
 
 /* Navigation tabs */
@@ -534,6 +620,16 @@ button:focus-visible {
   color: rgba(255, 255, 255, 0.85);
 }
 
+.medication-concentration {
+  display: block;
+  margin-top: 6px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: var(--primary);
+  text-transform: uppercase;
+  font-size: 0.85em;
+}
+
 .carousel-section {
   display: flex;
   flex-direction: column;
@@ -564,8 +660,8 @@ button:focus-visible {
 }
 
 .carousel-slide img {
-  width: min(340px, 85%);
-  max-height: 420px;
+  width: min(400px, 92%);
+  max-height: 520px;
   aspect-ratio: 3 / 4;
   object-fit: contain;
   border-radius: 14px;


### PR DESCRIPTION
## Summary
- add color-scheme, description, and social sharing metadata pointing to the new og.png image on both primary pages
- insert a reusable brand header with theme-aware logos and styled CloseDose title to reinforce branding
- refine medication guides with clearer concentration formatting, larger carousel imagery, and supporting styles including a light-mode background

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68cf70e6c4b48329bcb2f8dc2605d7db