### PR TITLE
Improve SEO metadata for CloseDose

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,8 @@
     content="Plan safe acetaminophen and ibuprofen dosing with CloseDose's pediatric calculator and medication guidance."
   />
   <meta property="og:image" content="images/og.png" />
+  <meta property="og:url" content="https://closedose.com/" />
+  <meta property="og:site_name" content="CloseDose" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="CloseDose | Pediatric Antipyretic Dose Calculator" />
   <meta
@@ -22,8 +24,46 @@
     content="Plan safe acetaminophen and ibuprofen dosing with CloseDose's pediatric calculator and medication guidance."
   />
   <meta name="twitter:image" content="images/og.png" />
+  <meta name="robots" content="index, follow" />
+  <link rel="canonical" href="https://closedose.com/" />
+  <link rel="alternate" href="https://closedose.com/" hreflang="en" />
   <title>CloseDose | Pediatric Antipyretic Dose Calculator</title>
   <link rel="stylesheet" href="./style.css" />
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      "name": "CloseDose",
+      "url": "https://closedose.com/",
+      "description": "CloseDose provides a pediatric antipyretic dose calculator and medication safety education for caregivers.",
+      "publisher": {
+        "@type": "Organization",
+        "name": "CloseDose",
+        "url": "https://closedose.com/",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "https://closedose.com/images/logo/CloseDose%20Logo_Black_2048_Transparent.png"
+        }
+      }
+    }
+  </script>
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Organization",
+      "name": "CloseDose",
+      "url": "https://closedose.com/",
+      "sameAs": [
+        "https://www.linkedin.com/company/closedose",
+        "https://www.instagram.com/closedose"
+      ],
+      "contactPoint": {
+        "@type": "ContactPoint",
+        "contactType": "customer support",
+        "email": "hello@closedose.com"
+      }
+    }
+  </script>
 </head>
 <body>
   <nav class="tabs">
@@ -47,6 +87,19 @@
 
   <main class="page">
     <div id="message" role="alert" aria-live="polite" hidden></div>
+
+    <section class="panel panel-intro">
+      <h2>Peace of Mind for Pediatric Fever and Pain Care</h2>
+      <p>
+        CloseDose.com empowers parents, guardians, and clinicians to quickly calculate safe pediatric acetaminophen and
+        ibuprofen doses with evidence-based guardrails. Our mission is to reduce medication errors while providing clear
+        caregiver education, dosing intervals, and weight-based recommendations for infants and children.
+      </p>
+      <p>
+        Bookmark CloseDose to keep pediatric antipyretic dosing guidance at your fingertips, and share the site with
+        families searching for trustworthy fever and pain relief support.
+      </p>
+    </section>
 
     <form id="calculator" class="panel panel-calculator" aria-labelledby="calculator-heading">
 

--- a/medication-guides.html
+++ b/medication-guides.html
@@ -15,6 +15,8 @@
     content="Explore pediatric acetaminophen and ibuprofen product concentrations with CloseDose medication guides."
   />
   <meta property="og:image" content="images/og.png" />
+  <meta property="og:url" content="https://closedose.com/medication-guides" />
+  <meta property="og:site_name" content="CloseDose" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="CloseDose | Medication Guides" />
   <meta
@@ -22,8 +24,62 @@
     content="Explore pediatric acetaminophen and ibuprofen product concentrations with CloseDose medication guides."
   />
   <meta name="twitter:image" content="images/og.png" />
+  <meta name="robots" content="index, follow" />
+  <link rel="canonical" href="https://closedose.com/medication-guides" />
+  <link rel="alternate" href="https://closedose.com/medication-guides" hreflang="en" />
   <title>Medication Guides</title>
   <link rel="stylesheet" href="./style.css" />
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "CollectionPage",
+      "name": "CloseDose Medication Guides",
+      "description": "CloseDose medication guides explain pediatric acetaminophen and ibuprofen products, concentrations, and dosing intervals for families.",
+      "url": "https://closedose.com/medication-guides",
+      "isPartOf": {
+        "@type": "WebSite",
+        "name": "CloseDose",
+        "url": "https://closedose.com/"
+      },
+      "mainEntity": {
+        "@type": "ItemList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "Acetaminophen Medication Guide",
+            "url": "https://closedose.com/medication-guides#acetaminophen"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "Ibuprofen Medication Guide",
+            "url": "https://closedose.com/medication-guides#ibuprofen"
+          }
+        ]
+      }
+    }
+  </script>
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {
+          "@type": "ListItem",
+          "position": 1,
+          "name": "CloseDose",
+          "item": "https://closedose.com/"
+        },
+        {
+          "@type": "ListItem",
+          "position": 2,
+          "name": "Medication Guides",
+          "item": "https://closedose.com/medication-guides"
+        }
+      ]
+    }
+  </script>
 </head>
 <body>
   <nav class="tabs">
@@ -52,8 +108,12 @@
         Use these quick references to understand common pain/fever medication options for infants and children.
         Always double-check the medication concentration and confirm dosing with your pediatrician or pharmacist.
       </p>
+      <p>
+        CloseDose.com collects trusted pediatric dosing visuals to help searchers identify the correct formulation and
+        avoid accidental double dosing when caring for babies, toddlers, and school-aged children.
+      </p>
       <div class="guide-grid">
-        <article class="guide-card guide-card-acetaminophen">
+        <article class="guide-card guide-card-acetaminophen" id="acetaminophen">
           <h2>Acetaminophen</h2>
           <section class="carousel-section" data-carousel>
             <h3>
@@ -109,7 +169,7 @@
             </ul>
           </div>
         </article>
-        <article class="guide-card guide-card-ibuprofen">
+        <article class="guide-card guide-card-ibuprofen" id="ibuprofen">
           <h2>Children's Ibuprofen</h2>
           <section class="carousel-section" data-carousel>
             <h3>

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://closedose.com/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://closedose.com/</loc>
+    <lastmod>2024-05-16</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://closedose.com/medication-guides</loc>
+    <lastmod>2024-05-16</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- add canonical URLs, robots directives, and structured data to primary pages for improved indexing
- introduce descriptive hero copy highlighting CloseDose.com value and pediatric dosing focus
- publish sitemap.xml and robots.txt so search engines can crawl key pages

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68cf912fee60832984db05c35a2f6104