### PR TITLE
Create reworked CloseDose landing page mockup

### DIFF
--- a/index-REWORK.html
+++ b/index-REWORK.html
@@ -1,0 +1,548 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>CloseDose – Pediatric Medication Dosing Calculator</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;900&family=Outfit:wght@500;600;700;800&display=swap" rel="stylesheet" />
+  <style>
+    :root {
+      --teal-dark: #104f4a;
+      --teal: #28b19a;
+      --teal-light: #e3f4f1;
+      --ink: #0f2c2a;
+      --white: #ffffff;
+      --shadow: 0 10px 0 #0f2c2a;
+      --radius-card: 36px;
+      --radius-inner: 22px;
+      --radius-pill: 999px;
+      --font-heading: "Outfit", "Nunito", sans-serif;
+      --font-body: "Nunito", sans-serif;
+    }
+
+    *, *::before, *::after {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      font-family: var(--font-body);
+      background: #f5faf8 url("bg.png") repeat;
+      background-size: 720px auto;
+      color: var(--ink);
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: stretch;
+    }
+
+    .skip-link {
+      position: absolute;
+      left: -9999px;
+    }
+    .skip-link:focus {
+      left: 16px;
+      top: 16px;
+      background: var(--white);
+      border: 3px solid var(--ink);
+      padding: 8px 16px;
+      z-index: 200;
+    }
+
+    .visually-hidden {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0 0 0 0);
+      white-space: nowrap;
+      border: 0;
+    }
+
+    header {
+      position: relative;
+      padding: 32px clamp(24px, 5vw, 64px) 0;
+      display: flex;
+      justify-content: flex-end;
+      align-items: center;
+    }
+
+    .menu-button {
+      width: 62px;
+      height: 62px;
+      border-radius: 50%;
+      border: 3px solid var(--ink);
+      background: var(--white);
+      display: grid;
+      place-items: center;
+      box-shadow: 0 6px 0 rgba(15, 44, 42, 0.85);
+    }
+
+    .menu-icon {
+      width: 26px;
+      height: 18px;
+      display: grid;
+      gap: 4px;
+    }
+    .menu-icon span {
+      display: block;
+      width: 100%;
+      height: 3px;
+      border-radius: 999px;
+      background: var(--ink);
+    }
+
+    main {
+      flex: 1;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      padding: clamp(32px, 6vw, 72px) clamp(16px, 5vw, 64px) 48px;
+    }
+
+    .calculator-shell {
+      width: min(540px, 100%);
+      background: rgba(255, 255, 255, 0.92);
+      border-radius: var(--radius-card);
+      border: 4px solid var(--ink);
+      box-shadow: var(--shadow);
+      padding: clamp(28px, 6vw, 48px);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: clamp(24px, 4vw, 36px);
+      text-align: center;
+    }
+
+    .brand {
+      display: grid;
+      justify-items: center;
+      gap: 12px;
+    }
+    .brand img {
+      width: 110px;
+      max-width: 40vw;
+    }
+    .brand-name {
+      font-family: var(--font-heading);
+      font-size: clamp(2rem, 4.8vw, 3.25rem);
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      font-weight: 800;
+      color: var(--ink);
+    }
+
+    form {
+      width: 100%;
+      display: grid;
+      gap: clamp(20px, 3vw, 32px);
+    }
+
+    .form-group {
+      background: var(--teal-light);
+      border: 3px solid var(--ink);
+      border-radius: var(--radius-inner);
+      padding: clamp(22px, 4vw, 30px);
+      display: grid;
+      gap: 18px;
+    }
+
+    .form-title {
+      font-family: var(--font-heading);
+      font-weight: 700;
+      font-size: clamp(1.1rem, 3vw, 1.4rem);
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .segmented {
+      display: grid;
+      gap: 14px;
+    }
+
+    .segmented-buttons {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 12px;
+    }
+
+    .segmented button {
+      border: 3px solid var(--ink);
+      border-radius: 18px;
+      background: var(--white);
+      font-family: var(--font-heading);
+      font-weight: 700;
+      font-size: clamp(0.85rem, 2.6vw, 1.05rem);
+      letter-spacing: 0.04em;
+      padding: 14px 12px;
+      text-transform: uppercase;
+      transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+      box-shadow: 0 6px 0 rgba(15, 44, 42, 0.6);
+      color: var(--ink);
+    }
+
+    .segmented button[aria-pressed="true"] {
+      background: var(--teal);
+      color: var(--white);
+      transform: translateY(2px);
+      box-shadow: 0 4px 0 rgba(15, 44, 42, 0.7);
+    }
+
+    .segmented button:focus-visible,
+    .unit-toggle button:focus-visible,
+    .action button:focus-visible {
+      outline: 3px solid #222;
+      outline-offset: 3px;
+    }
+
+    .hello-box {
+      background: var(--white);
+      border: 3px solid var(--ink);
+      border-radius: 18px;
+      padding: 18px;
+      font-size: 1.05rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+    }
+
+    .unit-row {
+      display: grid;
+      gap: 16px;
+    }
+
+    .weight-input {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .weight-input input[type="number"] {
+      width: min(100%, 220px);
+      border: 3px solid var(--ink);
+      border-radius: 18px;
+      padding: 14px 18px;
+      font-size: 1.1rem;
+      font-weight: 700;
+      text-align: center;
+      font-family: var(--font-heading);
+      box-shadow: 0 6px 0 rgba(15, 44, 42, 0.6);
+      background: var(--white);
+      color: var(--ink);
+      -moz-appearance: textfield;
+    }
+
+    .weight-input input::-webkit-outer-spin-button,
+    .weight-input input::-webkit-inner-spin-button {
+      -webkit-appearance: none;
+      margin: 0;
+    }
+
+    .unit-toggle {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 12px;
+    }
+
+    .unit-toggle button {
+      border: 3px solid var(--ink);
+      border-radius: 18px;
+      background: var(--white);
+      font-family: var(--font-heading);
+      font-weight: 700;
+      font-size: 1rem;
+      padding: 12px;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      box-shadow: 0 5px 0 rgba(15, 44, 42, 0.55);
+      transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+    }
+
+    .unit-toggle button[aria-pressed="true"] {
+      background: var(--teal);
+      color: var(--white);
+      transform: translateY(2px);
+      box-shadow: 0 3px 0 rgba(15, 44, 42, 0.7);
+    }
+
+    .action button {
+      width: 100%;
+      border: 3px solid var(--ink);
+      border-radius: 18px;
+      background: var(--teal);
+      color: var(--white);
+      font-family: var(--font-heading);
+      font-weight: 800;
+      font-size: clamp(1.05rem, 3.4vw, 1.4rem);
+      letter-spacing: 0.2em;
+      text-transform: uppercase;
+      padding: 18px;
+      box-shadow: 0 8px 0 rgba(15, 44, 42, 0.75);
+      transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+      cursor: pointer;
+    }
+
+    .action button:disabled {
+      background: #aacdc6;
+      cursor: not-allowed;
+      box-shadow: 0 6px 0 rgba(15, 44, 42, 0.5);
+    }
+
+    .action button:not(:disabled):active {
+      transform: translateY(2px);
+      box-shadow: 0 4px 0 rgba(15, 44, 42, 0.7);
+    }
+
+    #message {
+      margin: 0;
+      background: #fff;
+      border-radius: 18px;
+      border: 3px solid var(--ink);
+      padding: 18px 20px;
+      font-weight: 600;
+      line-height: 1.5;
+      text-align: left;
+    }
+
+    #results {
+      text-align: left;
+      display: grid;
+      gap: 16px;
+    }
+
+    #results p {
+      margin: 0;
+      line-height: 1.45;
+    }
+
+    #results .medication-heading {
+      font-size: 1.05rem;
+      font-weight: 800;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+
+    #results .dose-note {
+      font-size: 0.95rem;
+      font-weight: 600;
+      color: #124643;
+    }
+
+    #results .dose-note-emphasis {
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+
+    footer {
+      text-align: center;
+      font-size: 0.85rem;
+      color: #32514e;
+      padding: 16px 24px 40px;
+      line-height: 1.5;
+    }
+
+    footer small {
+      display: block;
+      max-width: 960px;
+      margin: 0 auto;
+    }
+
+    /* Mobile tweaks */
+    @media (max-width: 720px) {
+      header {
+        padding-top: 20px;
+      }
+      .menu-button {
+        width: 54px;
+        height: 54px;
+      }
+      .calculator-shell {
+        border-width: 3px;
+        border-radius: 28px;
+        padding: 28px 20px;
+        box-shadow: 0 7px 0 #0f2c2a;
+      }
+      .form-group {
+        border-radius: 20px;
+        padding: 22px 18px;
+      }
+      .segmented-buttons {
+        grid-template-columns: 1fr;
+      }
+      .unit-toggle {
+        grid-template-columns: 1fr 1fr;
+      }
+    }
+
+    @media (max-width: 480px) {
+      .calculator-shell {
+        gap: 20px;
+      }
+      .hello-box {
+        font-size: 0.95rem;
+      }
+      #message {
+        font-size: 0.95rem;
+      }
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#calculator">Skip to calculator</a>
+  <header>
+    <button class="menu-button" type="button" aria-label="Open menu">
+      <span class="menu-icon" aria-hidden="true">
+        <span></span>
+        <span></span>
+        <span></span>
+      </span>
+    </button>
+  </header>
+  <main>
+    <section class="calculator-shell" aria-labelledby="calculator-title">
+      <div class="brand">
+        <img src="images/logo-hex2tone.png" alt="CloseDose logo" />
+        <div class="brand-name" id="calculator-title">CloseDose</div>
+      </div>
+      <form id="calculator" novalidate>
+        <div class="form-group" aria-live="polite">
+          <div class="form-title">Patient Age</div>
+          <div class="segmented">
+            <div class="segmented-buttons" role="group" aria-label="Select patient age">
+              <button type="button" class="age-option" data-age="0-2" aria-pressed="false">0-2 Months</button>
+              <button type="button" class="age-option" data-age="2-6" aria-pressed="false">2-6 Months</button>
+              <button type="button" class="age-option" data-age="6+" aria-pressed="false">6+ Months</button>
+            </div>
+            <p class="hello-box">HELLO.</p>
+          </div>
+          <select id="age" name="age" aria-hidden="true" tabindex="-1">
+            <option value="">Select age</option>
+            <option value="0-2">0-2 Months</option>
+            <option value="2-6">2-6 Months</option>
+            <option value="6+">6+ Months</option>
+          </select>
+          <p id="message" hidden></p>
+        </div>
+
+        <div class="form-group">
+          <div class="form-title">Patient Weight</div>
+          <div class="unit-row">
+            <div class="weight-input">
+              <label for="weight" class="visually-hidden">Enter weight</label>
+              <input type="number" id="weight" name="weight" inputmode="decimal" placeholder="Enter weight" min="0" step="0.1" />
+            </div>
+            <div class="unit-toggle" role="group" aria-label="Select weight unit">
+              <button type="button" class="unit-option" data-unit="lbs" aria-pressed="true">lbs</button>
+              <button type="button" class="unit-option" data-unit="kg" aria-pressed="false">kg</button>
+            </div>
+          </div>
+          <select id="weight-unit" name="weight-unit" aria-hidden="true" tabindex="-1">
+            <option value="lbs" selected>lbs</option>
+            <option value="kg">kg</option>
+          </select>
+        </div>
+
+        <div class="action">
+          <button type="submit">Calculate</button>
+        </div>
+        <div id="results" aria-live="polite"></div>
+      </form>
+    </section>
+  </main>
+  <footer>
+    <small>Disclaimer: This tool is for educational purposes only and is not a substitute for professional medical advice. Consult with a licensed healthcare provider before administering medications. Sponsored in part by CloseDose, Madison, WI, USA.</small>
+  </footer>
+
+  <script src="script.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const ageSelect = document.getElementById('age');
+      const ageButtons = document.querySelectorAll('.age-option');
+      const unitSelect = document.getElementById('weight-unit');
+      const unitButtons = document.querySelectorAll('.unit-option');
+      const calculateButton = document.querySelector('.action button');
+
+      function setAge(value) {
+        if (ageSelect) {
+          ageSelect.value = value;
+          ageSelect.dispatchEvent(new Event('change'));
+        }
+        updateAgeButtons();
+        if (typeof updateForm === 'function') {
+          updateForm();
+        }
+      }
+
+      function updateAgeButtons() {
+        const currentValue = ageSelect ? ageSelect.value : '';
+        ageButtons.forEach((button) => {
+          const isActive = button.dataset.age === currentValue;
+          button.setAttribute('aria-pressed', String(isActive));
+        });
+      }
+
+      ageButtons.forEach((button) => {
+        button.addEventListener('click', () => {
+          const value = button.dataset.age || '';
+          setAge(value);
+        });
+      });
+
+      if (ageSelect) {
+        ageSelect.addEventListener('change', () => {
+          updateAgeButtons();
+          if (typeof updateForm === 'function') {
+            updateForm();
+          }
+        });
+      }
+
+      function setUnit(value) {
+        if (unitSelect) {
+          unitSelect.value = value;
+          unitSelect.dispatchEvent(new Event('change'));
+        }
+        const currentValue = unitSelect ? unitSelect.value : '';
+        unitButtons.forEach((button) => {
+          const isActive = button.dataset.unit === currentValue;
+          button.setAttribute('aria-pressed', String(isActive));
+        });
+      }
+
+      unitButtons.forEach((button) => {
+        button.addEventListener('click', () => {
+          const value = button.dataset.unit || 'lbs';
+          setUnit(value);
+        });
+      });
+
+      if (unitSelect) {
+        unitSelect.addEventListener('change', () => {
+          const currentValue = unitSelect.value;
+          unitButtons.forEach((button) => {
+            const isActive = button.dataset.unit === currentValue;
+            button.setAttribute('aria-pressed', String(isActive));
+          });
+        });
+      }
+
+      if (calculateButton) {
+        calculateButton.addEventListener('click', () => {
+          if (typeof updateForm === 'function') {
+            updateForm();
+          }
+        });
+      }
+
+      updateAgeButtons();
+      if (unitSelect) {
+        setUnit(unitSelect.value || 'lbs');
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a new `index-REWORK.html` page that recreates the supplied desktop/mobile CloseDose mockup
- restyle the calculator with segmented age/unit controls while reusing the existing dosing logic
- add accessibility helpers, responsive tweaks, and background/branding assets to match the reference design

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d05af83c408329b2456d76c92dfdbe