### PR TITLE
Align logo apple with bright theme color

### DIFF
--- a/script.js
+++ b/script.js
@@ -116,7 +116,7 @@ async function updateWordmarkImages(colors) {
 
     let svgText = await response.text();
     const replacements = [
-      { pattern: /#123934/gi, value: colors.dark },
+      { pattern: /#123934/gi, value: colors.bright },
       { pattern: /#0a3a35/gi, value: colors.dark },
       { pattern: /#24a687/gi, value: colors.bright },
     ];


### PR DESCRIPTION
## Summary
- ensure the apple emblem in the CloseDose wordmark uses the bright palette color alongside the DOSE "OSE" letters by updating the SVG color replacement map

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d4e81643ac8329a48d37ab5c33bbb7