### PR TITLE
Update collapsed logo container styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -308,7 +308,7 @@
       inset: 0;
       background: var(--surface);
       border: var(--border-width) solid var(--theme-dark);
-      clip-path: polygon(25% 0, 75% 0, 100% 50%, 75% 100%, 25% 100%, 0 50%);
+      border-radius: clamp(18px, 4vw, 28px);
       box-shadow: var(--shadow-pill);
       opacity: 0;
       transform: translateX(-120%) scale(0.92);
@@ -358,14 +358,20 @@
     }
 
     body.logo-collapsed .logo-link {
-      width: 100%;
+      width: auto;
       max-width: clamp(160px, 32vw, 260px);
+      padding: clamp(10px, 2.6vw, 16px) clamp(14px, 3.6vw, 22px);
       box-shadow: var(--shadow-pill);
     }
 
     body.logo-collapsed .logo-link::before {
       opacity: 1;
       transform: translateX(0);
+      border-radius: clamp(18px, 4vw, 28px);
+    }
+
+    body.logo-collapsed #logo-sequence {
+      width: clamp(120px, 28vw, 200px);
     }
 
     .sr-only {


### PR DESCRIPTION
## Summary
- replace the collapsed logo hexagon background with a rounded square to mirror the menu button styling
- adjust the collapsed logo sizing and padding so the logo/button sits away from the top-left edge

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d4eb415fd48329856ad8ac058cd29c