### PR TITLE
Adjust collapsed logo button sizing and colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -383,9 +383,10 @@
     }
 
     body.logo-collapsed .logo-link {
-      width: auto;
-      max-width: clamp(160px, 32vw, 260px);
-      padding: clamp(10px, 2.6vw, 16px) clamp(14px, 3.6vw, 22px);
+      width: clamp(120px, 26vw, 176px);
+      height: clamp(120px, 26vw, 176px);
+      padding: clamp(10px, 2.6vw, 16px);
+      padding-left: clamp(8px, 2.1vw, 14px);
       box-shadow: var(--shadow-pill);
     }
 
@@ -396,7 +397,8 @@
     }
 
     body.logo-collapsed #logo-sequence {
-      width: clamp(120px, 28vw, 200px);
+      width: 100%;
+      height: auto;
     }
 
     .sr-only {

--- a/script.js
+++ b/script.js
@@ -116,7 +116,7 @@ async function updateWordmarkImages(colors) {
 
     let svgText = await response.text();
     const replacements = [
-      { pattern: /#123934/gi, value: colors.bright },
+      { pattern: /#123934/gi, value: colors.dark },
       { pattern: /#0a3a35/gi, value: colors.dark },
       { pattern: /#24a687/gi, value: colors.bright },
     ];


### PR DESCRIPTION
## Summary
- force the collapsed logo container to render as a square with tighter left padding so the mark fills the rounded button
- let the collapsed logo image span the available space inside the square container
- align the secondary dark fill in the SVG wordmark with the dynamically generated dark theme color

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4ed4461a08329819e5f9bf6299e2e