### PR TITLE
Style: color code calculator results warnings

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,10 @@
       --text-on-dark: #ffffff;
       --warning-soft: rgba(255, 171, 64, 0.22);
       --danger-soft: rgba(244, 67, 54, 0.15);
+      --warning-orange-bg: #fff3e0;
+      --warning-orange-text: #c25a00;
+      --warning-red-bg: #fdecea;
+      --warning-red-text: #c62828;
       --card-left: 28px;
       --stack1: var(--theme-bright-lighter);
       --stack2: var(--theme-bright-soft);
@@ -703,11 +707,30 @@
     }
 
     .warning-card--orange {
-      background: var(--warning-soft);
+      background: var(--warning-orange-bg);
+      color: var(--warning-orange-text);
+      font-weight: 800;
+      border-color: var(--warning-orange-text);
     }
 
     .warning-card--red-soft {
-      background: var(--danger-soft);
+      background: var(--warning-red-bg);
+      color: var(--warning-red-text);
+      font-weight: 800;
+      border-color: var(--warning-red-text);
+    }
+
+    .warning-card--red-note {
+      background: var(--warning-red-bg);
+      color: var(--warning-red-text);
+      font-style: italic;
+      font-weight: 600;
+      border-color: var(--warning-red-text);
+    }
+
+    .warning-card--red-note em {
+      color: inherit;
+      font-style: inherit;
     }
 
     .disclaimer-section {

--- a/script.js
+++ b/script.js
@@ -312,7 +312,7 @@ function calculateDose() {
       renderWarning(
         '',
         '<em>Ibuprofen is not recommended for infants under six months. Consult your pediatrician before using ibuprofen for this age group.</em>',
-        'warning-card--red-soft'
+        'warning-card--red-note'
       )
     );
 


### PR DESCRIPTION
## Summary
- add dedicated theme variables for orange and red warning styles in the calculator results pane
- style medication dose warnings and infant alerts with orange and red accented backgrounds and typography
- apply a specialized red italic warning style to the ibuprofen guidance for children under six months

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d4f0a0a8c483299a7823d80af11b90