### PR TITLE
Shrink collapsed logo button

### DIFF
--- a/index.html
+++ b/index.html
@@ -371,7 +371,7 @@
       position: fixed;
       top: clamp(18px, 5vw, 26px);
       left: clamp(18px, 6vw, 36px);
-      width: clamp(160px, 32vw, 260px);
+      width: clamp(110px, 22vw, 174px);
       transform: none;
       z-index: 2200;
       padding-bottom: 0;
@@ -387,17 +387,17 @@
     }
 
     body.logo-collapsed .logo-link {
-      width: clamp(120px, 26vw, 176px);
-      height: clamp(120px, 26vw, 176px);
-      padding: clamp(10px, 2.6vw, 16px);
-      padding-left: clamp(8px, 2.1vw, 14px);
+      width: clamp(80px, 18vw, 118px);
+      height: clamp(80px, 18vw, 118px);
+      padding: clamp(6px, 1.8vw, 12px);
       box-shadow: var(--shadow-pill);
     }
 
     body.logo-collapsed .logo-link::before {
       opacity: 1;
       transform: translateX(0);
-      border-radius: clamp(18px, 4vw, 28px);
+      border-radius: clamp(16px, 3vw, 22px);
+      inset: clamp(2px, 0.7vw, 6px);
     }
 
     body.logo-collapsed #logo-sequence {
@@ -816,11 +816,11 @@
       body.logo-collapsed .logo-shell {
         top: 16px;
         left: 16px;
-        width: clamp(150px, 40vw, 230px);
+        width: clamp(100px, 27vw, 154px);
       }
 
       body.logo-collapsed .logo-link {
-        max-width: clamp(150px, 40vw, 230px);
+        max-width: clamp(100px, 27vw, 154px);
       }
 
       .menu-btn {

--- a/medication-guides.html
+++ b/medication-guides.html
@@ -264,7 +264,7 @@
       position: fixed;
       top: clamp(18px, 5vw, 26px);
       left: clamp(18px, 6vw, 36px);
-      width: clamp(160px, 32vw, 260px);
+      width: clamp(110px, 22vw, 174px);
       transform: none;
       z-index: 2200;
       padding-bottom: 0;
@@ -280,20 +280,21 @@
     }
 
     body.logo-collapsed .logo-link {
-      width: auto;
-      max-width: clamp(160px, 32vw, 260px);
-      padding: clamp(10px, 2.6vw, 16px) clamp(14px, 3.6vw, 22px);
+      width: clamp(80px, 18vw, 118px);
+      height: clamp(80px, 18vw, 118px);
+      padding: clamp(6px, 1.8vw, 12px);
       box-shadow: var(--shadow-pill);
     }
 
     body.logo-collapsed .logo-link::before {
       opacity: 1;
       transform: translateX(0);
-      border-radius: clamp(18px, 4vw, 28px);
+      border-radius: clamp(16px, 3vw, 22px);
+      inset: clamp(2px, 0.7vw, 6px);
     }
 
     body.logo-collapsed #logo-sequence {
-      width: clamp(120px, 28vw, 200px);
+      width: 100%;
     }
 
     .sr-only {


### PR DESCRIPTION
## Summary
- reduce the collapsed header logo button so the pseudo-button sits as a centered square behind the logo artwork
- update the collapsed header sizing clamps across pages that use the animated logo shell for consistent behavior

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d55e97c31c8329b89232676b4f6d19