### PR TITLE
Refresh Pass the Pointer deck with this month's 6 POCUS cases

### DIFF
--- a/pocus-presentation.html
+++ b/pocus-presentation.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Pass the Pointer — POCUS in Pediatric EM | May 2026</title>
+<title>Pass the Pointer — POCUS in Pediatric EM | This Month's Cases | May 2026</title>
 <style>
   :root {
     --teal: #00b4b4;
@@ -463,43 +463,43 @@
   <div>
     <span class="case-tag tag-title">Pass the Pointer</span>
     <h1 style="font-size:clamp(32px,5vw,64px); margin-bottom: 12px;">POCUS in Pediatric EM</h1>
-    <p class="lead">6 Cases · 45 Minutes · May 2026</p>
-    <p class="small" style="margin-top:8px;">Pediatric Emergency Medicine Department</p>
+    <p class="lead">6 Cases from This Month · 45 Minutes</p>
+    <p class="small" style="margin-top:8px;">Pediatric Emergency Medicine Department · May 2026</p>
   </div>
   <div class="case-overview-grid">
     <div class="case-thumb" onclick="goTo(2)">
       <div class="case-num">Case 1 · PEM</div>
-      <h3>Pyloric Stenosis</h3>
-      <p>6-week-old, projectile vomiting</p>
+      <h3>Biliary Sludge</h3>
+      <p>15 y/o SCD, RUQ pain after meals</p>
     </div>
     <div class="case-thumb" onclick="goTo(5)">
       <div class="case-num">Case 2 · PEM</div>
       <h3>Intussusception</h3>
-      <p>20-month-old, colicky pain</p>
+      <p>18-month-old, colicky pain, lethargy</p>
     </div>
     <div class="case-thumb" onclick="goTo(8)">
       <div class="case-num">Case 3 · PEM</div>
-      <h3>Appendicitis</h3>
-      <p>10-year-old, RLQ pain</p>
+      <h3>Pneumothorax</h3>
+      <p>17 y/o tall thin male, pleuritic CP</p>
     </div>
     <div class="case-thumb" onclick="goTo(11)">
       <div class="case-num">Case 4 · PEM</div>
-      <h3>Pediatric Lung US</h3>
-      <p>4-year-old, fever + hypoxia</p>
+      <h3>Cardiac POCUS</h3>
+      <p>12 y/o, post-viral CP &amp; effusion</p>
     </div>
     <div class="case-thumb" onclick="goTo(14)">
-      <div class="case-num">Case 5 · Urology</div>
-      <h3>Testicular Torsion</h3>
-      <p>14-year-old, acute scrotal pain</p>
+      <div class="case-num">Case 5 · MSK/Proc</div>
+      <h3>Femur Fracture + FICB</h3>
+      <p>5 y/o, refuses to bear weight</p>
     </div>
     <div class="case-thumb" onclick="goTo(17)">
       <div class="case-num">Case 6 · Trauma</div>
-      <h3>eFAST Exam</h3>
-      <p>16-year-old, MVC, unstable</p>
+      <h3>Positive FAST</h3>
+      <p>10 y/o, pedestrian vs MVC</p>
     </div>
   </div>
   <div class="spacer"></div>
-  <p class="small" style="text-align:center;">← → Arrow keys or buttons below to navigate</p>
+  <p class="small" style="text-align:center;">← → Arrow keys or buttons below to navigate · Press T to start the 45-min timer</p>
 </div>
 
 <!-- ═══════════════════════════════════════════
@@ -522,12 +522,12 @@
       <h3>45-Minute Timeline</h3>
       <div class="timeline" style="margin-top:8px;">
         <div class="timeline-item"><div class="timeline-dot"></div><p><strong>0–2 min</strong> — Intro &amp; housekeeping</p></div>
-        <div class="timeline-item"><div class="timeline-dot"></div><p><strong>2–9 min</strong> — Case 1: Pyloric Stenosis</p></div>
+        <div class="timeline-item"><div class="timeline-dot"></div><p><strong>2–9 min</strong> — Case 1: Biliary Sludge</p></div>
         <div class="timeline-item"><div class="timeline-dot"></div><p><strong>9–16 min</strong> — Case 2: Intussusception</p></div>
-        <div class="timeline-item"><div class="timeline-dot"></div><p><strong>16–23 min</strong> — Case 3: Appendicitis</p></div>
-        <div class="timeline-item"><div class="timeline-dot"></div><p><strong>23–30 min</strong> — Case 4: Lung US</p></div>
-        <div class="timeline-item"><div class="timeline-dot"></div><p><strong>30–37 min</strong> — Case 5: Testicular Torsion</p></div>
-        <div class="timeline-item"><div class="timeline-dot"></div><p><strong>37–44 min</strong> — Case 6: eFAST Exam</p></div>
+        <div class="timeline-item"><div class="timeline-dot"></div><p><strong>16–23 min</strong> — Case 3: Pneumothorax</p></div>
+        <div class="timeline-item"><div class="timeline-dot"></div><p><strong>23–30 min</strong> — Case 4: Cardiac POCUS</p></div>
+        <div class="timeline-item"><div class="timeline-dot"></div><p><strong>30–37 min</strong> — Case 5: Femur Fx + FICB</p></div>
+        <div class="timeline-item"><div class="timeline-dot"></div><p><strong>37–44 min</strong> — Case 6: Positive FAST</p></div>
         <div class="timeline-item"><div class="timeline-dot green"></div><p><strong>44–45 min</strong> — Q&amp;A / wrap-up</p></div>
       </div>
     </div>
@@ -548,78 +548,80 @@
 </div>
 
 <!-- ═══════════════════════════════════════════
-     SLIDE 2 — CASE 1 DIVIDER
+     SLIDE 2 — CASE 1 DIVIDER · GALLBLADDER SLUDGE
 ══════════════════════════════════════════════ -->
 <div class="slide section-slide">
   <span class="case-tag tag-pem">Case 1 · PEM</span>
   <div class="case-number-big">01</div>
-  <h2 style="margin-top:8px; font-size:clamp(24px,4vw,48px);">Pyloric Stenosis</h2>
-  <p class="lead" style="margin-top:8px;">"The baby that keeps projectile vomiting"</p>
+  <h2 style="margin-top:8px; font-size:clamp(24px,4vw,48px);">Biliary Sludge</h2>
+  <p class="lead" style="margin-top:8px;">"The teenager with sickle cell and RUQ pain after dinner"</p>
 </div>
 
 <!-- ═══════════════════════════════════════════
      SLIDE 3 — CASE 1 HISTORY
 ══════════════════════════════════════════════ -->
 <div class="slide">
-  <span class="case-tag tag-pem">Case 1 · PEM — Pyloric Stenosis</span>
+  <span class="case-tag tag-pem">Case 1 · PEM — Biliary Sludge</span>
   <h2 style="margin-bottom:14px;">Clinical Presentation</h2>
   <div class="col-6040">
     <div class="stack">
       <div class="card">
         <h3>History</h3>
         <ul style="margin-top:6px;">
-          <li><strong>6-week-old male</strong>, born at 38 weeks, no prior issues</li>
-          <li>3-day history of <strong>non-bilious projectile vomiting</strong> after every feed</li>
-          <li>Initially spitting up → now forceful ejection across the room</li>
-          <li>Still hungry and eager to feed immediately after vomiting ("hungry vomiter")</li>
-          <li>Last wet diaper 10 hours ago</li>
-          <li>No fever, no diarrhea</li>
-          <li>Father had pyloric stenosis as an infant</li>
+          <li><strong>15-year-old female</strong> with HbSS sickle cell disease, on hydroxyurea</li>
+          <li>3-week history of intermittent <strong>RUQ pain</strong>, now constant for 12 hours</li>
+          <li>Pain worse <strong>30–60 min after meals</strong>, especially fried foods</li>
+          <li>Nausea, 2 episodes of non-bilious emesis</li>
+          <li>No fever, no jaundice noted by family</li>
+          <li>Last pain crisis 4 months ago — pain feels "different"</li>
+          <li>Family hx: mother had cholecystectomy at 28</li>
         </ul>
       </div>
       <div class="card-accent">
         <h3>Exam</h3>
         <ul style="margin-top:6px;">
-          <li>HR 148, RR 36, T 37.1°C, Weight 4.1 kg</li>
-          <li>Sunken fontanelle, dry mucous membranes</li>
-          <li>Abdomen: soft, non-distended, "olive" palpable in epigastrium <span class="badge badge-yellow">10–20% of cases</span></li>
-          <li>Visible peristaltic waves left → right (rare, pathognomonic)</li>
+          <li>HR 102, BP 118/72, T 37.4°C, SpO₂ 98%</li>
+          <li>Mild scleral icterus</li>
+          <li>RUQ tenderness, voluntary guarding, <strong>positive Murphy's sign</strong></li>
+          <li>No rebound, no peritoneal signs</li>
+          <li>Labs: WBC 11.2, T.bili 2.6, ALT 48, AST 52, lipase normal, retic 8%</li>
         </ul>
       </div>
       <div class="card-yellow">
-        <h4>Classic Labs</h4>
-        <p>Hypochloremic, hypokalemic <strong>metabolic alkalosis</strong><br>
-        <span class="small">Na↓ · K↓ · Cl↓↓ · HCO₃↑↑ · pH↑</span></p>
+        <h4>Why Peds with Biliary Disease?</h4>
+        <p class="small">Hemolytic anemias (SCD, spherocytosis, thalassemia) · TPN dependence · Cystic fibrosis · Obesity / rapid weight loss · Prolonged fasting · <strong>Ceftriaxone pseudolithiasis</strong> (reversible) · Pregnancy</p>
       </div>
     </div>
     <div class="stack">
       <div class="card-teal">
         <h3>Why POCUS?</h3>
-        <p style="margin-top:6px;">Ultrasound is the <strong>gold standard</strong> for pyloric stenosis — no radiation, bedside, fast, and highly accurate.</p>
+        <p style="margin-top:6px;">Right-upper-quadrant POCUS is bedside, fast, and rules in/out the most common biliary pathology. Test of choice for symptomatic cholelithiasis in children.</p>
         <div style="margin-top:10px;" class="measure-grid">
           <div class="measure-item">
-            <div class="measure-value">97%</div>
-            <div class="measure-label">Sensitivity</div>
+            <div class="measure-value">90–95%</div>
+            <div class="measure-label">Sens (stones)</div>
           </div>
           <div class="measure-item">
-            <div class="measure-value">99%</div>
+            <div class="measure-value">96–98%</div>
             <div class="measure-label">Specificity</div>
           </div>
         </div>
+        <p class="small" style="margin-top:6px;">POCUS Murphy's sign + GB findings outperforms either alone for cholecystitis.</p>
       </div>
       <div class="card-accent">
         <h4>Differential Dx</h4>
         <ul class="no-bullet">
-          <li>GERD / overfeeding</li>
-          <li>Malrotation / volvulus <span class="badge badge-red">must exclude</span></li>
-          <li>Adrenal insufficiency</li>
-          <li>Overfeeding / formula intolerance</li>
-          <li>Antral web (rare)</li>
+          <li>Symptomatic cholelithiasis / biliary colic</li>
+          <li>Acute cholecystitis <span class="badge badge-yellow">don't miss</span></li>
+          <li>Choledocholithiasis / cholangitis</li>
+          <li>Pancreatitis (gallstone-induced)</li>
+          <li>Splenic sequestration / hepatic crisis (SCD)</li>
+          <li>FHCS / hepatitis</li>
         </ul>
       </div>
       <div class="card-red">
-        <h4>🚨 Key Question</h4>
-        <p>Non-bilious vs bilious? Bilious = malrotation until proven otherwise.</p>
+        <h4>🚨 Sludge ≠ Innocent</h4>
+        <p>Sludge can cause acute cholecystitis, gallstone pancreatitis, and biliary obstruction — especially in hemolytic disease and TPN. Treat the symptomatic patient, not the picture.</p>
       </div>
     </div>
   </div>
@@ -629,7 +631,7 @@
      SLIDE 4 — CASE 1 ULTRASOUND
 ══════════════════════════════════════════════ -->
 <div class="slide">
-  <span class="case-tag tag-pem">Case 1 · PEM — Pyloric Stenosis</span>
+  <span class="case-tag tag-pem">Case 1 · PEM — Biliary Sludge</span>
   <h2 style="margin-bottom:14px;">Ultrasound Technique &amp; Findings</h2>
   <div class="cols-2">
     <div class="stack scroll-inner">
@@ -637,93 +639,91 @@
         <div class="probe-icon">🔬</div>
         <div>
           <h4>Probe &amp; Settings</h4>
-          <p><strong>High-frequency linear</strong> 7–15 MHz</p>
-          <p class="small">Neonates: highest frequency available · Gain up slightly</p>
+          <p><strong>Curvilinear</strong> 2–5 MHz (adolescents) · <strong>High-frequency linear</strong> for small children/infants</p>
+          <p class="small">Depth 10–14 cm · Focus on near field · Patient ideally NPO 6h (gallbladder distended)</p>
         </div>
       </div>
       <div class="card">
-        <h3>Patient Positioning &amp; Prep</h3>
-        <div class="algo-step">
-          <div class="algo-num">1</div>
-          <p>Right lateral decubitus or supine — positions stomach over pylorus</p>
-        </div>
-        <div class="algo-step">
-          <div class="algo-num">2</div>
-          <p>Offer 10–20 mL of clear liquid or formula — fills stomach to trace pylorus</p>
-        </div>
-        <div class="algo-step">
-          <div class="algo-num">3</div>
-          <p>Find gallbladder first (right epigastrium) — pylorus lies medial to it</p>
-        </div>
-        <div class="algo-step">
-          <div class="algo-num">4</div>
-          <p>Follow gastric antrum distally to the pyloric channel</p>
-        </div>
-        <div class="algo-step">
-          <div class="algo-num">5</div>
-          <p>Obtain transverse AND longitudinal views — confirm both planes</p>
-        </div>
+        <h3>Technique — "7s, sweep, scan"</h3>
+        <div class="algo-step"><div class="algo-num">1</div><p>Patient supine; have them <strong>take a deep breath and hold</strong> — pushes liver/GB caudal under ribs</p></div>
+        <div class="algo-step"><div class="algo-num">2</div><p>Probe at <strong>subxiphoid R</strong>, marker to patient's head; sweep laterally toward MAL</p></div>
+        <div class="algo-step"><div class="algo-num">3</div><p>Identify the <strong>"exclamation point"</strong>: GB long-axis + main lobar fissure pointing to portal triad</p></div>
+        <div class="algo-step"><div class="algo-num">4</div><p>Rotate 90° → transverse / short axis. Sweep entire GB neck → fundus</p></div>
+        <div class="algo-step"><div class="algo-num">5</div><p>Measure <strong>anterior wall</strong> perpendicular to lumen (avoid posterior wall — acoustic enhancement falsely thins it)</p></div>
+        <div class="algo-step"><div class="algo-num">6</div><p>Measure <strong>CBD</strong> just anterior to portal vein; identify on "Mickey Mouse" view</p></div>
+        <div class="algo-step"><div class="algo-num">7</div><p>Reposition patient <strong>L lateral decubitus</strong> if GB collapsed or sludge unclear — sludge SHIFTS, polyps don't</p></div>
       </div>
       <div class="card-teal">
         <h3>Diagnostic Criteria</h3>
         <div class="measure-grid">
           <div class="measure-item abnormal">
-            <div class="measure-value">≥4</div>
+            <div class="measure-value">&gt;3</div>
             <div class="measure-unit">mm</div>
-            <div class="measure-label">Muscle Thickness (single wall)</div>
+            <div class="measure-label">Anterior wall (abnormal)</div>
           </div>
           <div class="measure-item abnormal">
-            <div class="measure-value">≥17</div>
+            <div class="measure-value">&gt;4</div>
             <div class="measure-unit">mm</div>
-            <div class="measure-label">Channel Length</div>
+            <div class="measure-label">CBD (peds &gt;1y)</div>
           </div>
-          <div class="measure-item abnormal">
-            <div class="measure-value">≥14</div>
+          <div class="measure-item">
+            <div class="measure-value">&lt;2</div>
             <div class="measure-unit">mm</div>
-            <div class="measure-label">Pyloric Diameter</div>
+            <div class="measure-label">CBD infants</div>
           </div>
         </div>
-        <p class="small" style="margin-top:8px;">Single wall thickness ≥4 mm is the most reliable criterion. Premature infants: adjust cutoffs.</p>
+        <p class="small" style="margin-top:8px;">CBD = 1 mm per decade of life (rough peds rule). Wall &gt;3 mm + Murphy's + pericholecystic fluid = cholecystitis.</p>
       </div>
     </div>
     <div class="stack scroll-inner">
       <div class="cols-2" style="flex:unset; grid-template-columns:1fr 1fr; gap:10px;">
         <div class="sign-card">
-          <div class="sign-emoji">🍩</div>
-          <div class="sign-name">Donut Sign</div>
-          <div class="sign-desc">Transverse view — hypoechoic muscle ring surrounding echogenic mucosa and submucosa</div>
+          <div class="sign-emoji">🌫️</div>
+          <div class="sign-name">Sludge</div>
+          <div class="sign-desc">Low-level, <strong>non-shadowing</strong> echogenic material that layers dependently and SHIFTS with patient repositioning. "Like sand in honey."</div>
         </div>
         <div class="sign-card">
-          <div class="sign-emoji">🔱</div>
-          <div class="sign-name">Cervix Sign</div>
-          <div class="sign-desc">Longitudinal view — thickened pyloric muscle flanks the echogenic channel, resembles a cervix</div>
+          <div class="sign-emoji">🪨</div>
+          <div class="sign-name">Stones (WES sign)</div>
+          <div class="sign-desc"><strong>W</strong>all-<strong>E</strong>cho-<strong>S</strong>hadow: hyperechoic curvilinear stone + clean posterior shadow. Gravity-dependent, mobile.</div>
         </div>
         <div class="sign-card">
-          <div class="sign-emoji">🎯</div>
-          <div class="sign-name">Target Sign</div>
-          <div class="sign-desc">Concentric rings — inner echogenic mucosa, outer hypoechoic muscle on cross-section</div>
+          <div class="sign-emoji">🐭</div>
+          <div class="sign-name">Mickey Mouse Sign</div>
+          <div class="sign-desc">Portal triad cross-section: portal vein (face), CBD (right ear, anterior), hepatic artery (left ear). Use to ID + measure CBD.</div>
         </div>
         <div class="sign-card">
-          <div class="sign-emoji">🌊</div>
-          <div class="sign-name">Antiperistalsis</div>
-          <div class="sign-desc">Real-time: observe gastric fluid moving retrograde toward esophagus</div>
+          <div class="sign-emoji">👉</div>
+          <div class="sign-name">Sonographic Murphy</div>
+          <div class="sign-desc">Maximum tenderness with probe pressure directly over GB. 90% sens for cholecystitis when paired with wall thickening.</div>
         </div>
+      </div>
+      <div class="card-red" style="padding:10px 14px;">
+        <h3>Signs of Acute Cholecystitis</h3>
+        <ul style="margin-top:6px;">
+          <li>Anterior wall &gt;3 mm (most sensitive)</li>
+          <li><strong>Pericholecystic fluid</strong> (anechoic stripe outside wall)</li>
+          <li>GB distension &gt;4 cm transverse</li>
+          <li>Sonographic Murphy's sign</li>
+          <li>Striated / "double-wall" appearance (edema)</li>
+          <li>Impacted stone in GB neck (Hartmann's pouch)</li>
+        </ul>
       </div>
       <div class="pearl">
-        <strong>Pearl:</strong> The muscle appears hypoechoic (dark) — measure from outer edge to inner mucosa (not lumen). Don't include the mucosal layer.
+        <strong>Pearl — Sludge vs Tumefactive Sludge:</strong> A non-shadowing intraluminal mass that <em>moves</em> with repositioning = sludge. If it doesn't move, think polyp, adenomyomatosis, or GB carcinoma (rare in peds, but think mass in chronic SCD).
       </div>
       <div class="pearl">
-        <strong>Pearl:</strong> Watch in real-time for peristaltic waves that fail to open the pylorus — dynamic finding supporting obstruction.
+        <strong>Pearl — Ceftriaxone biliary pseudolithiasis:</strong> Up to 40% of kids on ceftriaxone develop sludge/stones — usually asymptomatic and reverses within weeks after discontinuation. Confirm med list before sending to surgery.
       </div>
       <div class="pitfall">
-        <strong>Pitfall:</strong> Mistaking the antrum for the pylorus — the antrum IS compressible. Trace all the way to where the channel closes.
+        <strong>Pitfall — Edge artifact / side-lobe artifact</strong> mimicking sludge: artifact disappears with repositioning probe angle. True sludge persists and layers dependently.
       </div>
       <div class="pitfall">
-        <strong>Pitfall:</strong> Air in the duodenum (shadowing) can obscure measurement. Change to right lateral decubitus, gentle pressure.
+        <strong>Pitfall — Wall thickening is NOT specific:</strong> hepatitis, CHF, hypoalbuminemia, ascites, post-prandial GB contraction all thicken the wall. Always interpret with clinical picture.
       </div>
       <div class="card-green">
         <h4>Disposition</h4>
-        <p>NPO · IV access · 0.9% NaCl 20 mL/kg bolus → maintenance · Correct alkalosis BEFORE OR · Surgical consult for pyloromyotomy (Ramstedt procedure) · Not a surgical emergency until electrolytes corrected</p>
+        <p>NPO · IV fluids · analgesia (consider ketorolac if no contraindication) · CBC/CMP/lipase/GGT · If T.bili ↑ or CBD dilated → MRCP/GI consult. <strong>SCD + symptomatic gallstones/sludge → surgical consult, elective cholecystectomy</strong> (high rate of recurrent cholestasis/crises). Cholecystitis = admit, IV abx (pip/tazo or cefoxitin), gen surg.</p>
       </div>
     </div>
   </div>
@@ -890,84 +890,80 @@
 </div>
 
 <!-- ═══════════════════════════════════════════
-     SLIDE 8 — CASE 3 DIVIDER
+     SLIDE 8 — CASE 3 DIVIDER · PNEUMOTHORAX
 ══════════════════════════════════════════════ -->
 <div class="slide section-slide">
   <span class="case-tag tag-pem">Case 3 · PEM</span>
   <div class="case-number-big">03</div>
-  <h2 style="margin-top:8px; font-size:clamp(24px,4vw,48px);">Pediatric Appendicitis</h2>
-  <p class="lead" style="margin-top:8px;">"The great masquerader"</p>
+  <h2 style="margin-top:8px; font-size:clamp(24px,4vw,48px);">Pneumothorax</h2>
+  <p class="lead" style="margin-top:8px;">"The tall, thin teenager who can't catch a breath"</p>
 </div>
 
 <!-- ═══════════════════════════════════════════
      SLIDE 9 — CASE 3 HISTORY
 ══════════════════════════════════════════════ -->
 <div class="slide">
-  <span class="case-tag tag-pem">Case 3 · PEM — Appendicitis</span>
+  <span class="case-tag tag-pem">Case 3 · PEM — Pneumothorax</span>
   <h2 style="margin-bottom:14px;">Clinical Presentation</h2>
   <div class="col-6040">
     <div class="stack">
       <div class="card">
         <h3>History</h3>
         <ul style="margin-top:6px;">
-          <li><strong>10-year-old male</strong></li>
-          <li>36-hour history of abdominal pain — started <strong>periumbilical</strong>, now localizing to <strong>RLQ</strong> (McBurney's point)</li>
-          <li>Anorexia, nausea, 1 episode of vomiting</li>
-          <li>Low-grade fever — parents noted this morning</li>
-          <li>Walking hunched over, pain worsens with movement</li>
+          <li><strong>17-year-old male</strong>, tall (6'3"), thin habitus, marfanoid features</li>
+          <li>Sudden onset <strong>left-sided pleuritic chest pain</strong> + dyspnea while sitting in class</li>
+          <li>Pain sharp, worse with deep inspiration, no radiation</li>
+          <li>No trauma, no recent illness</li>
+          <li>Active smoker (vape), no IV drug use</li>
+          <li>No prior episodes; uncle had "collapsed lung" twice in college</li>
         </ul>
       </div>
       <div class="card-accent">
         <h3>Exam</h3>
         <ul style="margin-top:6px;">
-          <li>T 38.7°C, HR 104, RR 20, SpO₂ 99%</li>
-          <li>RLQ tenderness, guarding, Rovsing's sign +, Psoas sign +</li>
-          <li>Rebound tenderness present</li>
-          <li>WBC 16,200 with 82% neutrophils, CRP 48 mg/L</li>
+          <li>HR 112, RR 24, BP 122/74, SpO₂ <strong>93% RA → 97% on 2L NC</strong>, T 36.9°C</li>
+          <li>Mild distress, splinting on left</li>
+          <li><strong>Decreased breath sounds left apex/anterior</strong>, hyperresonant percussion</li>
+          <li>Trachea midline · No JVD · Subcutaneous emphysema absent</li>
+          <li>No chest wall tenderness, no crepitus</li>
         </ul>
       </div>
-      <div class="card-teal">
-        <h4>Pediatric Appendicitis Score (PAS)</h4>
-        <div class="cols-2" style="flex:unset; gap:8px;">
-          <div>
-            <p class="small">Anorexia (+1) · Nausea/vomiting (+1)</p>
-            <p class="small">Migration of pain (+1) · Fever ≥38°C (+1)</p>
-            <p class="small">Cough/hop/percussion RLQ tenderness (+2)</p>
-          </div>
-          <div>
-            <p class="small">RLQ tenderness (+2) · WBC &gt;10k (+1)</p>
-            <p class="small">Polymorphonuclear neutrophilia (+1)</p>
-            <p class="small" style="margin-top:6px;"><strong>This patient: PAS 7/10</strong> <span class="badge badge-red">High Risk</span></p>
-          </div>
-        </div>
+      <div class="card-yellow">
+        <h4>Categories of Pediatric PTX</h4>
+        <p class="small"><strong>Primary spontaneous</strong> — tall thin adolescent males, apical blebs (this patient) · <strong>Secondary spontaneous</strong> — CF, asthma exacerbation, PJP, LCH · <strong>Traumatic</strong> — blunt/penetrating · <strong>Iatrogenic</strong> — central line, transbronchial bx, mechanical ventilation, NIPPV · <strong>Catamenial</strong> — endometriosis (rare in teens)</p>
       </div>
     </div>
     <div class="stack">
       <div class="card-teal">
-        <h3>Why POCUS First?</h3>
-        <p style="margin-top:6px;">POCUS + clinical score can reduce CT utilization in pediatrics. Goal: diagnose appendicitis with US, reserve CT for non-visualization or indeterminate cases.</p>
-        <div style="margin-top:10px;" class="measure-grid">
+        <h3>Why POCUS over CXR?</h3>
+        <div class="measure-grid">
           <div class="measure-item">
-            <div class="measure-value">72–85%</div>
-            <div class="measure-label">Sensitivity</div>
+            <div class="measure-value">86–98%</div>
+            <div class="measure-label">LUS Sensitivity</div>
           </div>
           <div class="measure-item">
-            <div class="measure-value">94–97%</div>
-            <div class="measure-label">Specificity</div>
+            <div class="measure-value">97–99%</div>
+            <div class="measure-label">LUS Specificity</div>
+          </div>
+          <div class="measure-item">
+            <div class="measure-value">~50%</div>
+            <div class="measure-label">Supine CXR Sens</div>
           </div>
         </div>
-        <p class="small" style="margin-top:6px;">Non-visualization rate 20–35% in EDs. ALARA: "US first" algorithms reduce CT use by 40–50%.</p>
+        <p class="small" style="margin-top:6px;">Supine CXR misses anterior PTX. LUS detects even small anterior PTX in seconds. No radiation.</p>
       </div>
       <div class="card-red">
-        <h4>🚨 Perforation Risk</h4>
-        <p>Children have higher perforation rates (~30–40%) due to diagnostic delay. Younger children (&lt;5y) may present atypically.</p>
+        <h4>🚨 Tension PTX = Clinical Dx</h4>
+        <p>Hypotension + tracheal deviation + absent breath sounds + JVD = <strong>needle decompress, do not delay for imaging</strong>. POCUS is for stable patients or to confirm tube placement after.</p>
       </div>
       <div class="card-accent">
-        <h4>Decision Algorithm (simplified)</h4>
+        <h4>Differential Dx</h4>
         <ul class="no-bullet">
-          <li>PAS ≤3 → Discharge with return precautions</li>
-          <li>PAS 4–6 → US first; CT if non-diagnostic</li>
-          <li>PAS ≥7 → US; direct OR if positive; CT if non-vis</li>
+          <li>Pleurisy / viral pleurodynia</li>
+          <li>PE (in older teens, OCP, smoking)</li>
+          <li>Pneumonia · MSK / costochondritis</li>
+          <li>Pericarditis / myocarditis</li>
+          <li>Esophageal rupture (vomiting hx)</li>
         </ul>
       </div>
     </div>
@@ -978,7 +974,7 @@
      SLIDE 10 — CASE 3 ULTRASOUND
 ══════════════════════════════════════════════ -->
 <div class="slide">
-  <span class="case-tag tag-pem">Case 3 · PEM — Appendicitis</span>
+  <span class="case-tag tag-pem">Case 3 · PEM — Pneumothorax</span>
   <h2 style="margin-bottom:14px;">Ultrasound Technique &amp; Findings</h2>
   <div class="cols-2">
     <div class="stack scroll-inner">
@@ -986,162 +982,144 @@
         <div class="probe-icon">🔬</div>
         <div>
           <h4>Probe &amp; Settings</h4>
-          <p><strong>High-frequency linear</strong> 7–12 MHz · <strong>Curvilinear</strong> for obese patients or deep structures</p>
-          <p class="small">Split screen or side-by-side color Doppler can assess hyperemia</p>
+          <p><strong>High-frequency linear</strong> 5–12 MHz (best for pleura) · Phased array acceptable if linear unavailable</p>
+          <p class="small"><strong>Turn OFF</strong> harmonics, multibeam, spatial compounding — they SMOOTH artifacts. Single focal zone at pleural line. Depth 4–6 cm.</p>
         </div>
       </div>
       <div class="card">
-        <h3>Graded Compression Technique</h3>
-        <div class="algo-step"><div class="algo-num">1</div><p>Start at ASIS, sweep medially and inferiorly with <strong>progressive gentle compression</strong></p></div>
-        <div class="algo-step"><div class="algo-num">2</div><p>Displace overlying bowel gas laterally — compress until you see psoas muscle</p></div>
-        <div class="algo-step"><div class="algo-num">3</div><p>Identify the cecum (haustra, largest gas-filled structure RLQ)</p></div>
-        <div class="algo-step"><div class="algo-num">4</div><p>Follow the cecum to the appendix origin at base — tip-to-base visualization required</p></div>
-        <div class="algo-step"><div class="algo-num">5</div><p>Measure <strong>outer wall to outer wall</strong> in transverse plane</p></div>
-        <div class="algo-step"><div class="algo-num">6</div><p>If not found: try posterior (retrocecal), or patient left lateral decubitus</p></div>
+        <h3>Technique — Supine PTX Scan</h3>
+        <div class="algo-step"><div class="algo-num">1</div><p>Patient supine — air rises to the <strong>most anterior point</strong>. Start at <strong>2nd–3rd ICS, midclavicular line</strong> bilaterally</p></div>
+        <div class="algo-step"><div class="algo-num">2</div><p>Probe marker cephalad (sagittal). Identify two ribs with shadow + <strong>bat sign</strong> (pleural line between rib heads)</p></div>
+        <div class="algo-step"><div class="algo-num">3</div><p>Watch <strong>pleural line</strong> for 5+ respiratory cycles — sliding = visceral on parietal pleura shimmer</p></div>
+        <div class="algo-step"><div class="algo-num">4</div><p>If no sliding: switch to <strong>M-mode</strong> across pleural line — seashore (normal) vs barcode/stratosphere (PTX)</p></div>
+        <div class="algo-step"><div class="algo-num">5</div><p>Slide laterally toward axilla searching for the <strong>lung point</strong> — pathognomonic for PTX</p></div>
+        <div class="algo-step"><div class="algo-num">6</div><p>Scan <strong>multiple zones</strong> bilaterally — anterior, lateral, post-axillary. Posterior basal for hemothorax/effusion if trauma</p></div>
       </div>
       <div class="card-teal">
-        <h3>Diagnostic Criteria</h3>
-        <div class="measure-grid">
-          <div class="measure-item abnormal">
-            <div class="measure-value">≥6</div>
-            <div class="measure-unit">mm</div>
-            <div class="measure-label">Outer-wall diameter</div>
-          </div>
-          <div class="measure-item">
-            <div class="measure-value">&lt;6</div>
-            <div class="measure-unit">mm</div>
-            <div class="measure-label">Normal (compressible)</div>
-          </div>
-        </div>
-        <p class="small" style="margin-top:8px;">6–8 mm = equivocal, consider CT/MRI. Normal appendix: compressible, blind-ending, peristalsis visible in adjacent bowel.</p>
+        <h3>Three-Step Diagnostic Algorithm</h3>
+        <ul style="margin-top:6px;">
+          <li><strong>Step 1:</strong> Absent lung sliding (SENS only; can be false +)</li>
+          <li><strong>Step 2:</strong> Absent B-lines (B-lines = no PTX, 100% specificity if seen)</li>
+          <li><strong>Step 3:</strong> Lung point identified (100% SPECIFIC for PTX)</li>
+        </ul>
+        <p class="small" style="margin-top:6px;">All three together → diagnostic. Lung point absent in complete (large) PTX — collapsed lung never touches chest wall.</p>
       </div>
     </div>
     <div class="stack scroll-inner">
       <div class="cols-2" style="flex:unset; grid-template-columns:1fr 1fr; gap:10px;">
         <div class="sign-card">
-          <div class="sign-emoji">🎯</div>
-          <div class="sign-name">Target Sign</div>
-          <div class="sign-desc">Transverse: non-compressible blind-ending tubular structure &gt;6mm, concentric rings</div>
+          <div class="sign-emoji">🦇</div>
+          <div class="sign-name">Bat Sign</div>
+          <div class="sign-desc">Two rib shadows ("wings") with pleural line spanning between ("body"). Confirms you're at pleura before assessing sliding.</div>
         </div>
         <div class="sign-card">
-          <div class="sign-emoji">🪨</div>
-          <div class="sign-name">Appendicolith</div>
-          <div class="sign-desc">Hyperechoic focus with posterior shadowing — increases perforation risk, should prompt urgent surgery</div>
+          <div class="sign-emoji">🏖️</div>
+          <div class="sign-name">Seashore vs Barcode</div>
+          <div class="sign-desc">M-mode: <strong>seashore</strong> (waves above, sand below) = normal sliding. <strong>Barcode/stratosphere</strong> (parallel lines throughout) = absent sliding = PTX.</div>
         </div>
         <div class="sign-card">
-          <div class="sign-emoji">✨</div>
-          <div class="sign-name">Fat Stranding</div>
-          <div class="sign-desc">Hyperechoic periappendiceal fat (mesenteric fat reaction) — nonspecific but supports diagnosis</div>
+          <div class="sign-emoji">📍</div>
+          <div class="sign-name">Lung Point</div>
+          <div class="sign-desc">Transition zone where sliding lung returns into a sliding-free field with each inspiration. <strong>100% specific.</strong> Marks size/extent of PTX.</div>
         </div>
         <div class="sign-card">
-          <div class="sign-emoji">💧</div>
-          <div class="sign-name">Periappendiceal Fluid</div>
-          <div class="sign-desc">Anechoic free fluid adjacent to appendix or in pelvis — look for complex/loculated fluid suggesting abscess</div>
+          <div class="sign-emoji">⚡</div>
+          <div class="sign-name">B-lines</div>
+          <div class="sign-desc">Vertical hyperechoic artifacts from pleural line to screen bottom. Presence of <em>any</em> B-line at that spot = visceral pleura present = NO PTX there.</div>
         </div>
-      </div>
-      <div class="card-red" style="padding:10px 14px;">
-        <h3>Perforation Signs</h3>
-        <ul style="margin-top:6px;">
-          <li>Loss of echogenic submucosal layer (wall disruption)</li>
-          <li>Periappendiceal abscess (complex fluid collection)</li>
-          <li>Phlegmon — hyperechoic mass with shadowing</li>
-          <li>Free intraperitoneal air (rare — posterior acoustic enhancement)</li>
-        </ul>
       </div>
       <div class="pearl">
-        <strong>Pearl:</strong> Graded compression is both diagnostic and therapeutic — it moves bowel gas aside to reveal the appendix. Never skip it.
+        <strong>Pearl — Find the lung point:</strong> Start anterior (in PTX region), then slowly slide lateral/inferior. The moment sliding reappears with each inspiration is the lung point. Quantifies PTX size: anterior lung point = small; mid-axillary = large.
+      </div>
+      <div class="pearl">
+        <strong>Pearl — "Lung pulse":</strong> If you see cardiac-pulsation transmitted to the pleural line WITHOUT sliding, lung is still apposed (atelectasis, mainstem intubation, apnea) — NOT pneumothorax. Useful to exclude PTX after intubation.
       </div>
       <div class="pitfall">
-        <strong>Pitfall:</strong> Retrocecal appendix (25% of cases) — won't compress anteriorly. Roll patient left lateral, scan posteriorly.
+        <strong>Pitfall — Things that mimic absent sliding:</strong> mainstem intubation, COPD bullae, ARDS, severe asthma with hyperinflation, pleural adhesions, subcutaneous emphysema (will also abolish sliding AND prevent imaging the pleura — clue: comet-tail artifacts in soft tissue).
       </div>
       <div class="pitfall">
-        <strong>Pitfall:</strong> Measuring the lumen instead of outer wall → underestimates diameter. Always outer-wall to outer-wall.
+        <strong>Pitfall — Pleural line above rib level:</strong> if you don't ID the bat sign first, you may be measuring chest wall fascia and falsely call PTX. Confirm 2 ribs + pleural line between them.
       </div>
       <div class="card-green">
         <h4>Disposition</h4>
-        <p>NPO · IV antibiotics if perforated (pip/tazo or amp/sulbactam) · Surgical consult · Non-perforated: OR or antibiotic-first shared decision · Perforated + abscess: IV abx → interval appendectomy</p>
+        <p>O₂ 100% NRB (Henry's law accelerates resorption) · <strong>Small primary spontaneous PTX (&lt;2 cm at apex)</strong> stable patient: observation + repeat imaging 4–6h. <strong>Large or symptomatic PTX</strong>: needle aspiration or small-bore pigtail (12–14F) at 4th–5th ICS mid-axillary (triangle of safety). Admit · Pediatric surgery / pulm consult · CT for blebs if recurrent · Counsel on flight/diving restrictions.</p>
       </div>
     </div>
   </div>
 </div>
 
 <!-- ═══════════════════════════════════════════
-     SLIDE 11 — CASE 4 DIVIDER
+     SLIDE 11 — CASE 4 DIVIDER · CARDIAC
 ══════════════════════════════════════════════ -->
 <div class="slide section-slide">
   <span class="case-tag tag-pem">Case 4 · PEM</span>
   <div class="case-number-big">04</div>
-  <h2 style="margin-top:8px; font-size:clamp(24px,4vw,48px);">Pediatric Lung Ultrasound</h2>
-  <p class="lead" style="margin-top:8px;">"The stethoscope of the 21st century"</p>
+  <h2 style="margin-top:8px; font-size:clamp(24px,4vw,48px);">Cardiac POCUS</h2>
+  <p class="lead" style="margin-top:8px;">"The post-viral teenager with chest pain — myocarditis or pericarditis?"</p>
 </div>
 
 <!-- ═══════════════════════════════════════════
      SLIDE 12 — CASE 4 HISTORY
 ══════════════════════════════════════════════ -->
 <div class="slide">
-  <span class="case-tag tag-pem">Case 4 · PEM — Lung Ultrasound</span>
+  <span class="case-tag tag-pem">Case 4 · PEM — Cardiac</span>
   <h2 style="margin-bottom:14px;">Clinical Presentation</h2>
   <div class="col-6040">
     <div class="stack">
       <div class="card">
         <h3>History</h3>
         <ul style="margin-top:6px;">
-          <li><strong>4-year-old female</strong></li>
-          <li>3 days of <strong>fever to 39.5°C</strong> and worsening cough</li>
-          <li>Progressive tachypnea, now working hard to breathe</li>
-          <li>Decreased oral intake, no sick contacts initially</li>
-          <li>No prior lung disease, vaccinations up to date</li>
-          <li>Father had URI 1 week ago</li>
+          <li><strong>12-year-old male</strong>, previously healthy</li>
+          <li>5 days of fever, cough, myalgias — improved 2 days ago</li>
+          <li>Now: <strong>substernal chest pain, worse supine, better leaning forward</strong></li>
+          <li>Progressive fatigue, decreased exercise tolerance, "feels short of breath walking upstairs"</li>
+          <li>1 episode of pre-syncope this morning</li>
+          <li>Sister had recent viral URI; no COVID exposure reported</li>
         </ul>
       </div>
       <div class="card-accent">
         <h3>Exam</h3>
         <ul style="margin-top:6px;">
-          <li>T 39.3°C, HR 148, RR 42, SpO₂ <strong>91% on RA → 97% on 2L NC</strong></li>
-          <li>Moderate subcostal/intercostal retractions</li>
-          <li>Right: <strong>decreased breath sounds at base</strong>, dullness to percussion</li>
-          <li>Left: clear</li>
-          <li>CXR would show: RLL opacity with blunting of right costophrenic angle</li>
+          <li>HR 128, BP 96/58 (low for age), RR 24, SpO₂ 96%, T 38.0°C</li>
+          <li>Mildly ill-appearing, JVP elevated, capillary refill 3s</li>
+          <li>Heart: <strong>distant heart sounds</strong>, soft S3 gallop, no friction rub today (was present yesterday at PCP)</li>
+          <li>Lungs: scattered bibasilar crackles</li>
+          <li>Liver edge palpable 2 cm below costal margin</li>
+          <li>ECG: <strong>diffuse low-voltage QRS</strong>, electrical alternans, PR depression</li>
+          <li>Troponin: 0.48 ng/mL (elevated), BNP 820</li>
         </ul>
       </div>
       <div class="card-yellow">
-        <h4>Clinical Question</h4>
-        <p>Pneumonia vs parapneumonic effusion? Does the effusion need drainage?<br>
-        <span class="small">Lung US can answer both questions at bedside, in real-time.</span></p>
+        <h4>The Clinical Question(s)</h4>
+        <p class="small">(1) Is there pericardial effusion? · (2) Is there tamponade physiology? · (3) Is LV function depressed (myocarditis)? · (4) Does the IVC suggest fluid responsiveness or congestion?</p>
       </div>
     </div>
     <div class="stack">
       <div class="card-teal">
-        <h3>Why Lung US over CXR?</h3>
-        <div class="measure-grid">
-          <div class="measure-item">
-            <div class="measure-value">96%</div>
-            <div class="measure-label">LUS Sensitivity</div>
-          </div>
-          <div class="measure-item">
-            <div class="measure-value">93%</div>
-            <div class="measure-label">LUS Specificity</div>
-          </div>
-          <div class="measure-item">
-            <div class="measure-value">87%</div>
-            <div class="measure-label">CXR Sensitivity</div>
-          </div>
-        </div>
-        <p class="small" style="margin-top:8px;">No radiation · Bedside · Dynamic assessment · Guides procedural planning</p>
-      </div>
-      <div class="card-accent">
-        <h4>Causes of Pediatric Effusion</h4>
-        <ul class="no-bullet">
-          <li>Parapneumonic (most common)</li>
-          <li>Empyema (complicated)</li>
-          <li>Malignancy (leukemia, lymphoma)</li>
-          <li>Chylothorax</li>
-          <li>Heart failure (transudate)</li>
+        <h3>5 Quick Questions of Cardiac POCUS</h3>
+        <ul style="margin-top:6px;">
+          <li>1. Is there an <strong>effusion</strong>?</li>
+          <li>2. Is there <strong>tamponade physiology</strong>?</li>
+          <li>3. Is the <strong>LV global function</strong> normal/reduced?</li>
+          <li>4. Is the <strong>RV</strong> dilated (strain)?</li>
+          <li>5. What's the <strong>IVC</strong> doing (volume status)?</li>
         </ul>
+        <p class="small" style="margin-top:6px;">Goal-directed echo (not formal echo) — answer binary questions in 2–3 min.</p>
       </div>
       <div class="card-red">
-        <h4>🚨 Danger Signs</h4>
-        <p>Septated effusion · Loculated complex fluid · Lung herniation into effusion · All = empyema until proven otherwise</p>
+        <h4>🚨 Tamponade is CLINICAL + ECHO</h4>
+        <p>Beck's triad (hypotension + muffled sounds + JVD), pulsus paradoxus &gt;10 mmHg, AND echo findings (RA/RV diastolic collapse, IVC plethora). <strong>Never make pericardiocentesis decision on echo alone.</strong></p>
+      </div>
+      <div class="card-accent">
+        <h4>Differential</h4>
+        <ul class="no-bullet">
+          <li>Viral myocarditis (coxsackie, adeno, COVID, parvo)</li>
+          <li>Pericarditis ± effusion</li>
+          <li>MIS-C (kids, post-COVID 2–6 wks)</li>
+          <li>Acute rheumatic carditis</li>
+          <li>Dilated cardiomyopathy</li>
+          <li>Anomalous coronary artery (sports/syncope clue)</li>
+        </ul>
       </div>
     </div>
   </div>
@@ -1151,7 +1129,7 @@
      SLIDE 13 — CASE 4 ULTRASOUND
 ══════════════════════════════════════════════ -->
 <div class="slide">
-  <span class="case-tag tag-pem">Case 4 · PEM — Lung Ultrasound</span>
+  <span class="case-tag tag-pem">Case 4 · PEM — Cardiac</span>
   <h2 style="margin-bottom:14px;">Ultrasound Technique &amp; Findings</h2>
   <div class="cols-2">
     <div class="stack scroll-inner">
@@ -1159,334 +1137,337 @@
         <div class="probe-icon">🔬</div>
         <div>
           <h4>Probe &amp; Settings</h4>
-          <p><strong>Phased array</strong> (adults, older kids) · <strong>Linear</strong> (neonates/infants — highest resolution)</p>
-          <p class="small">No special lung preset needed. Harmonics off for B-lines. Depth 6–8 cm for most peds.</p>
+          <p><strong>Phased array</strong> 2–5 MHz (cardiac preset) · Linear acceptable for very small infants</p>
+          <p class="small">Indicator orientation: <em>cardiac convention</em> (indicator right of screen). Most US machines auto-flip when "Cardiac" preset is selected. Depth: 12–16 cm in teens.</p>
         </div>
       </div>
       <div class="card">
-        <h3>Scanning Zones (BLUE Protocol)</h3>
-        <p class="small" style="margin-bottom:8px;">6 zones per side: anterior upper/lower, lateral, posterior upper/lower/basal</p>
-        <div class="zone-grid">
-          <div class="zone highlight">Ant Upper</div>
-          <div class="zone highlight">Ant Lower</div>
-          <div class="zone">Lateral</div>
-          <div class="zone highlight">Post Upper</div>
-          <div class="zone highlight">Post Lower</div>
-          <div class="zone highlight">Post Basal</div>
+        <h3>Four Core Views</h3>
+        <div class="algo-step"><div class="algo-num">1</div>
+          <div><p><strong>Parasternal Long Axis (PSLA)</strong></p><p class="small">L sternal border 3rd–4th ICS, marker R shoulder. See LV, LA, AV, MV. Look for posterior effusion, LV size, EPSS &gt;7 mm = poor EF.</p></div>
         </div>
-        <p class="small" style="margin-top:6px;">Posterior basal zones most sensitive for pneumonia (gravity-dependent consolidation)</p>
+        <div class="algo-step"><div class="algo-num">2</div>
+          <div><p><strong>Parasternal Short Axis (PSSA)</strong></p><p class="small">Rotate 90° clockwise. "Donut" of LV with mitral valve at top. Assess LV function (eyeballed FAC), septal motion, regional WMA, "D-sign" RV strain.</p></div>
+        </div>
+        <div class="algo-step"><div class="algo-num">3</div>
+          <div><p><strong>Apical 4-Chamber (A4C)</strong></p><p class="small">Apex (PMI), marker patient L. All 4 chambers visible. Compare chamber sizes (RV should be ≤⅔ LV). Look for chamber collapse and TR.</p></div>
+        </div>
+        <div class="algo-step"><div class="algo-num">4</div>
+          <div><p><strong>Subxiphoid (Sub4 + IVC)</strong></p><p class="small">Probe just below xiphoid, aimed L shoulder, near liver. Best for effusion + pericardium. Then rotate sagittal → IVC longitudinal entering RA.</p></div>
+        </div>
       </div>
       <div class="card-teal">
-        <h3>Normal Lung US Findings</h3>
-        <ul style="margin-top:6px;">
-          <li><strong>Pleural line</strong>: bright, hyperechoic, moves with respiration</li>
-          <li><strong>Lung sliding</strong>: shimmering movement of visceral on parietal pleura</li>
-          <li><strong>A-lines</strong>: horizontal reverberation artifacts (air in lung = normal)</li>
-          <li><strong>Seashore sign</strong>: M-mode — "waves on a beach" above pleural line, granular below</li>
-        </ul>
-      </div>
-      <div class="card">
-        <h3>Effusion Assessment</h3>
-        <ul style="margin-top:6px;">
-          <li><strong>Simple/anechoic</strong>: transudate or early exudate</li>
-          <li><strong>Complex/echogenic</strong>: exudate, hemorrhage, empyema</li>
-          <li><strong>Septations</strong>: fibrinous stranding within fluid = complicated</li>
-          <li>Measure largest AP dimension above diaphragm</li>
-          <li>Mark safe spot for thoracentesis or chest drain placement</li>
-        </ul>
+        <h3>Eyeballing LV Function</h3>
+        <div class="measure-grid">
+          <div class="measure-item">
+            <div class="measure-value">&gt;55%</div>
+            <div class="measure-label">Normal EF</div>
+          </div>
+          <div class="measure-item">
+            <div class="measure-value">30–55%</div>
+            <div class="measure-label">Moderately ↓</div>
+          </div>
+          <div class="measure-item abnormal">
+            <div class="measure-value">&lt;30%</div>
+            <div class="measure-label">Severely ↓</div>
+          </div>
+        </div>
+        <p class="small" style="margin-top:6px;">Eyeball: vigorous endocardial excursion + walls thickening &gt;30% → normal. <strong>EPSS</strong> (E-point septal separation in PSLA) &gt;7 mm correlates with EF &lt;50%.</p>
       </div>
     </div>
     <div class="stack scroll-inner">
       <div class="cols-2" style="flex:unset; grid-template-columns:1fr 1fr; gap:10px;">
         <div class="sign-card">
-          <div class="sign-emoji">⚡</div>
-          <div class="sign-name">B-lines</div>
-          <div class="sign-desc">Vertical laser-like hyperechoic artifacts from pleural line to bottom of screen — move with sliding. ≥3 per field = pathologic. Interstitial fluid.</div>
+          <div class="sign-emoji">⚫</div>
+          <div class="sign-name">Pericardial Effusion</div>
+          <div class="sign-desc">Anechoic stripe surrounding heart in pericardial sac. <strong>Small</strong> &lt;1 cm, <strong>moderate</strong> 1–2 cm, <strong>large</strong> &gt;2 cm in diastole. Distinguishes from pleural by passing anterior to descending aorta in PSLA.</div>
         </div>
         <div class="sign-card">
-          <div class="sign-emoji">🫁</div>
-          <div class="sign-name">Consolidation</div>
-          <div class="sign-desc">Tissue-like (hepatization) echogenicity replacing normal air-filled lung. Jagged border (shred sign) at air-consolidation interface.</div>
+          <div class="sign-emoji">💔</div>
+          <div class="sign-name">RV Diastolic Collapse</div>
+          <div class="sign-desc">RV free wall buckles inward during diastole (mitral valve OPEN) — earliest sign of tamponade physiology. Use M-mode through RV to confirm timing.</div>
         </div>
         <div class="sign-card">
-          <div class="sign-emoji">💨</div>
-          <div class="sign-name">Air Bronchograms</div>
-          <div class="sign-desc"><strong>Dynamic</strong> = patent airways (pneumonia). <strong>Static</strong> = atelectasis. Fluid bronchograms = anechoic tubes in consolidation = complicated.</div>
+          <div class="sign-emoji">↔️</div>
+          <div class="sign-name">RA Systolic Collapse</div>
+          <div class="sign-desc">RA wall inversion lasting &gt;⅓ of cardiac cycle — sensitive (94%) but earlier/less specific than RV collapse.</div>
         </div>
         <div class="sign-card">
-          <div class="sign-emoji">🌊</div>
-          <div class="sign-name">Sinusoid Sign</div>
-          <div class="sign-desc">M-mode: lung moves toward pleura in inspiration creating sinusoidal pattern — confirms free-flowing effusion (vs empyema)</div>
+          <div class="sign-emoji">🫧</div>
+          <div class="sign-name">IVC Plethora</div>
+          <div class="sign-desc">Dilated IVC &gt;2 cm (or age-adjusted) with &lt;50% inspiratory collapse — supports tamponade or RV failure. Empty/collapsing IVC ≠ tamponade.</div>
         </div>
+      </div>
+      <div class="card-red" style="padding:10px 14px;">
+        <h3>Effusion vs Fat Pad vs Pleural Effusion</h3>
+        <ul style="margin-top:6px;">
+          <li><strong>Pericardial fat:</strong> anterior only, hypoechoic but echogenic specks, moves with heart, does NOT extend posteriorly</li>
+          <li><strong>Pericardial effusion:</strong> circumferential, anechoic, passes BETWEEN heart and descending aorta in PSLA</li>
+          <li><strong>Pleural effusion:</strong> passes POSTERIOR to descending aorta in PSLA — different space entirely</li>
+        </ul>
       </div>
       <div class="pearl">
-        <strong>Pearl:</strong> Dynamic air bronchograms (hyperechoic dots moving toward probe during inspiration) = pneumonia, not atelectasis. This distinction can change management (antibiotics vs physiotherapy).
+        <strong>Pearl — Myocarditis on POCUS:</strong> Look for globally reduced LV function, sometimes with regional WMA mimicking ischemia. Effusion is common but small. Combine with troponin + ECG to support diagnosis. Cardiac MRI is the gold standard.
       </div>
       <div class="pearl">
-        <strong>Pearl:</strong> Compare bilateral posterior zones — even subtle asymmetry in B-line density suggests pathology on the side with more.
+        <strong>Pearl — "RUSH" check in undifferentiated shock:</strong> Pump (LV/RV function, effusion) · Tank (IVC + abdominal FAST + lungs for B-lines) · Pipes (aorta for AAA — yes even in kids with connective tissue disease, DVT for PE).
       </div>
       <div class="pitfall">
-        <strong>Pitfall:</strong> Skin fold or subcutaneous emphysema can abolish lung sliding — don't diagnose pneumothorax on absence of sliding alone without other features (absent B-lines + lung point).
+        <strong>Pitfall — Anterior epicardial fat misread as effusion:</strong> if "fluid" is anterior only and doesn't move dependent, it's fat. Always check posterior PSLA and subxiphoid views.
       </div>
       <div class="pitfall">
-        <strong>Pitfall:</strong> Right-sided "effusion" below the diaphragm = intrahepatic fluid or ascites. Always identify the diaphragm first.
+        <strong>Pitfall — A small pericardial effusion does not equal small clinical impact:</strong> rapidly accumulating effusions (200 mL) can tamponade; chronic effusions of 1 L may not. Physiology over volume.
       </div>
       <div class="card-green">
         <h4>Disposition</h4>
-        <p>O₂ to maintain SpO₂ ≥94% · IV amoxicillin/ampicillin (typical) or ceftriaxone · Simple effusion: treat underlying pneumonia · Complex/empyema: chest tube or VATS, surgery consult · Admit all with SpO₂ &lt;95% or significant effusion</p>
+        <p>NPO · IV access (avoid aggressive fluid in pure tamponade) · Cardiology consult immediately · Pediatric ICU if hemodynamically compromised. <strong>Pericardiocentesis</strong> only if tamponade with hemodynamic instability — ideally in cath lab; bedside US-guided subxiphoid approach if peri-arrest. Treat myocarditis: supportive, inotropic support if needed, IVIG/steroids per cardiology in MIS-C.</p>
       </div>
     </div>
   </div>
 </div>
 
 <!-- ═══════════════════════════════════════════
-     SLIDE 14 — CASE 5 DIVIDER
+     SLIDE 14 — CASE 5 DIVIDER · FEMUR FRACTURE + FICB
 ══════════════════════════════════════════════ -->
 <div class="slide section-slide">
-  <span class="case-tag tag-urology">Case 5 · Urology</span>
+  <span class="case-tag tag-urology">Case 5 · MSK / Procedural</span>
   <div class="case-number-big" style="background: linear-gradient(135deg, var(--orange) 0%, rgba(255,123,67,0.2) 100%); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text;">05</div>
-  <h2 style="margin-top:8px; font-size:clamp(24px,4vw,48px);">Testicular Torsion</h2>
-  <p class="lead" style="margin-top:8px;">"Time is testicle" — every hour matters</p>
+  <h2 style="margin-top:8px; font-size:clamp(24px,4vw,48px);">Femur Fracture + Nerve Block</h2>
+  <p class="lead" style="margin-top:8px;">"Diagnose the cortex, then block the nerve"</p>
 </div>
 
 <!-- ═══════════════════════════════════════════
      SLIDE 15 — CASE 5 HISTORY
 ══════════════════════════════════════════════ -->
 <div class="slide">
-  <span class="case-tag tag-urology">Case 5 · Urology — Testicular Torsion</span>
+  <span class="case-tag tag-urology">Case 5 · MSK / Proc — Femur Fracture + FICB</span>
   <h2 style="margin-bottom:14px;">Clinical Presentation</h2>
   <div class="col-6040">
     <div class="stack">
       <div class="card">
         <h3>History</h3>
         <ul style="margin-top:6px;">
-          <li><strong>14-year-old male</strong></li>
-          <li>Woke from sleep with <strong>sudden onset left testicular pain</strong> 5 hours ago</li>
-          <li>Nausea, 1 episode of vomiting</li>
-          <li>No fever, no dysuria, no trauma</li>
-          <li>No prior episodes</li>
-          <li>Denies sexual activity</li>
+          <li><strong>5-year-old male</strong>, fell ~6 ft from playground monkey bars 2 hours ago</li>
+          <li>Landed on R hip / lateral thigh; immediate inability to bear weight</li>
+          <li>Crying, points to mid-R thigh as area of worst pain</li>
+          <li>No LOC, no head injury, no other complaints</li>
+          <li>NPO since lunch (3 hours ago)</li>
+          <li>No bleeding disorder, no allergies, no prior surgeries</li>
         </ul>
       </div>
       <div class="card-accent">
         <h3>Exam</h3>
         <ul style="margin-top:6px;">
-          <li>HR 98, afebrile, BP 118/70</li>
-          <li>Left testis: high-riding, <strong>horizontal (transverse) lie</strong></li>
-          <li>Left testis tender to light touch, swollen, firm</li>
-          <li>Cremasteric reflex: <strong>absent left</strong>, present right</li>
-          <li>Prehn's sign negative (elevation doesn't relieve pain)</li>
-          <li>Scrotal skin: minimal erythema, no warmth (early presentation)</li>
+          <li>HR 130 (in pain), BP 102/64, RR 22, T 37.0°C</li>
+          <li>R thigh: moderate swelling mid-shaft, no obvious deformity, no break in skin</li>
+          <li>R lower extremity neurovascularly intact — sensation, motion, pulses normal distal</li>
+          <li>Pain 9/10 with any movement, refuses to flex hip/knee</li>
+          <li>FAST exam negative · No other injuries · GCS 15</li>
+          <li>X-ray pending; "midshaft femur fracture, transverse, minimally displaced"</li>
         </ul>
       </div>
-      <div class="card-orange">
-        <h4>Bimodal Age Distribution</h4>
-        <p>Peak 1: <strong>Perinatal</strong> (extravaginal torsion) · Peak 2: <strong>12–18 years</strong> (intravaginal, bell-clapper deformity)</p>
-        <p class="small" style="margin-top:4px;">Bell-clapper deformity = bilateral in 40% → both testicles at risk</p>
+      <div class="card-yellow">
+        <h4>Two POCUS Roles in This Case</h4>
+        <p class="small"><strong>(1) Diagnostic:</strong> Identify cortical disruption when X-ray is delayed or equivocal (occult fx, ED triage). <strong>(2) Procedural:</strong> US-guided <strong>fascia iliaca compartment block (FICB)</strong> for opioid-sparing pain control.</p>
       </div>
     </div>
     <div class="stack">
       <div class="card-orange">
-        <h3>Time to Salvage</h3>
+        <h3>Why FICB &gt; Opioids in Kids</h3>
         <div class="measure-grid">
           <div class="measure-item">
-            <div class="measure-value" style="color:var(--green);">&gt;90%</div>
-            <div class="measure-label">Salvage &lt;6 hrs</div>
+            <div class="measure-value">75–90%</div>
+            <div class="measure-label">Pain reduction</div>
           </div>
           <div class="measure-item">
-            <div class="measure-value" style="color:var(--yellow);">50%</div>
-            <div class="measure-label">Salvage 12–24 hrs</div>
-          </div>
-          <div class="measure-item">
-            <div class="measure-value" style="color:var(--red);">&lt;10%</div>
-            <div class="measure-label">Salvage &gt;24 hrs</div>
+            <div class="measure-value">~6 hrs</div>
+            <div class="measure-label">Duration (ropivacaine)</div>
           </div>
         </div>
-      </div>
-      <div class="card-red">
-        <h4>🚨 Critical Rule</h4>
-        <p>If clinical suspicion is <strong>high</strong> for torsion, <strong>do not delay to OR for imaging</strong>. POCUS is adjunct, not a gatekeeper. When in doubt, call urology first.</p>
+        <p class="small" style="margin-top:6px;">Lower opioid requirement · No respiratory depression · Facilitates splinting, X-ray, transport · ACEP and AAP endorse for peds femur fx.</p>
       </div>
       <div class="card-accent">
-        <h4>Differential Diagnosis</h4>
+        <h4>FICB vs Femoral Nerve Block</h4>
         <ul class="no-bullet">
-          <li>Torsion of appendix testis (most common misdiagnosis)</li>
-          <li>Epididymo-orchitis</li>
-          <li>Incarcerated inguinal hernia</li>
-          <li>Trauma / hematocele</li>
-          <li>Tumor (painless, slow onset)</li>
+          <li>FICB blocks <strong>femoral + LFCN + obturator</strong> (3-in-1)</li>
+          <li>Larger spread under fascia iliaca — better coverage for mid-shaft</li>
+          <li>Less reliant on identifying nerve precisely</li>
+          <li>Safer in less-experienced hands</li>
         </ul>
+      </div>
+      <div class="card-red">
+        <h4>🚨 Don't Miss</h4>
+        <p>Isolated femur fx can lose up to 20% of blood volume in thigh (peds). Reassess hemodynamics; assess for compartment syndrome (rare but exists). Bilateral femur fx in young child without major mechanism → <strong>NAT screen</strong>.</p>
       </div>
     </div>
   </div>
 </div>
 
 <!-- ═══════════════════════════════════════════
-     SLIDE 16 — CASE 5 ULTRASOUND
+     SLIDE 16 — CASE 5 ULTRASOUND + PROCEDURE
 ══════════════════════════════════════════════ -->
 <div class="slide">
-  <span class="case-tag tag-urology">Case 5 · Urology — Testicular Torsion</span>
-  <h2 style="margin-bottom:14px;">Ultrasound Technique &amp; Findings</h2>
+  <span class="case-tag tag-urology">Case 5 · MSK / Proc — Femur Fracture + FICB</span>
+  <h2 style="margin-bottom:14px;">Ultrasound &amp; Procedural Technique</h2>
   <div class="cols-2">
     <div class="stack scroll-inner">
       <div class="probe-box">
         <div class="probe-icon">🔬</div>
         <div>
           <h4>Probe &amp; Settings</h4>
-          <p><strong>High-frequency linear</strong> 12–15 MHz · Hockey stick probe for smaller patients</p>
-          <p class="small">Highest sensitivity color/power Doppler settings · Low PRF · Color box large enough to cover full testis</p>
+          <p><strong>High-frequency linear</strong> 7–15 MHz for both fracture ID and nerve block</p>
+          <p class="small">Depth 3–5 cm for groin block · MSK preset (some machines) · Use a sterile probe cover for the block</p>
         </div>
       </div>
       <div class="card">
-        <h3>Technique</h3>
-        <div class="algo-step"><div class="algo-num">1</div><p><strong>Start with the normal side</strong> — establish baseline flow for comparison</p></div>
-        <div class="algo-step"><div class="algo-num">2</div><p>Gray scale bilateral: assess size, echotexture, hydrocele, epididymis</p></div>
-        <div class="algo-step"><div class="algo-num">3</div><p>Apply color Doppler bilaterally — use same settings both sides</p></div>
-        <div class="algo-step"><div class="algo-num">4</div><p>Power Doppler: more sensitive for low-flow states (late torsion)</p></div>
-        <div class="algo-step"><div class="algo-num">5</div><p>Image spermatic cord in transverse — look for <strong>whirlpool sign</strong></p></div>
-        <div class="algo-step"><div class="algo-num">6</div><p>Document any asymmetry in flow — even reduced flow is abnormal</p></div>
+        <h3>Part 1 — POCUS Femur Fx Detection</h3>
+        <div class="algo-step"><div class="algo-num">1</div><p>Probe in <strong>long axis</strong> over the anterolateral thigh, find the smooth hyperechoic cortex of femur</p></div>
+        <div class="algo-step"><div class="algo-num">2</div><p>Scan proximal to distal along entire shaft — look for <strong>cortical step-off, irregularity, or hematoma</strong> overlying disruption</p></div>
+        <div class="algo-step"><div class="algo-num">3</div><p>Rotate 90° to short axis at site of suspected fx for confirmation</p></div>
+        <div class="algo-step"><div class="algo-num">4</div><p><strong>"Lipohemarthrosis sign"</strong> at adjacent joint = intra-articular extension</p></div>
+        <div class="algo-step"><div class="algo-num">5</div><p>Document: image showing cortical break + measure displacement if applicable</p></div>
+        <p class="small" style="margin-top:8px;">Sens ~90%, Spec ~95% for long-bone fx in trained EM users. Useful in austere settings, occult fx, triage prioritization.</p>
       </div>
       <div class="card-teal">
-        <h3>Diagnostic Accuracy</h3>
-        <div class="measure-grid">
-          <div class="measure-item">
-            <div class="measure-value">88–97%</div>
-            <div class="measure-label">Sensitivity</div>
-          </div>
-          <div class="measure-item">
-            <div class="measure-value">97–99%</div>
-            <div class="measure-label">Specificity</div>
-          </div>
-        </div>
-        <p class="small" style="margin-top:8px;">Sensitivity lower for <strong>intermittent torsion</strong> (may have normal flow at time of scan). Clinical suspicion overrides imaging.</p>
+        <h3>Part 2 — Fascia Iliaca Block (FICB)</h3>
+        <div class="algo-step"><div class="algo-num">1</div><p>Sterile prep groin · Sedation if needed (intranasal midazolam or ketamine)</p></div>
+        <div class="algo-step"><div class="algo-num">2</div><p>Probe transverse at <strong>inguinal crease</strong> — identify femoral artery (pulsatile)</p></div>
+        <div class="algo-step"><div class="algo-num">3</div><p><strong>Lateral to artery:</strong> femoral nerve (hyperechoic honeycomb, "triangular"); deep to fascia iliaca, above iliopsoas muscle</p></div>
+        <div class="algo-step"><div class="algo-num">4</div><p>Slide probe ~1–2 cm <strong>lateral</strong> to artery — over sartorius/iliacus junction (away from vessel)</p></div>
+        <div class="algo-step"><div class="algo-num">5</div><p>In-plane needle approach lateral → medial, pop through <strong>fascia lata then fascia iliaca</strong> (two "pops")</p></div>
+        <div class="algo-step"><div class="algo-num">6</div><p>Aspirate (negative for blood) → inject 1 mL test → see hypoechoic spread <strong>under fascia iliaca, above iliopsoas</strong> in a "lens" shape</p></div>
+        <div class="algo-step"><div class="algo-num">7</div><p>Inject full dose, fanning to track spread medially toward femoral nerve. Reassess pain in 15–20 min</p></div>
       </div>
     </div>
     <div class="stack scroll-inner">
       <div class="cols-2" style="flex:unset; grid-template-columns:1fr 1fr; gap:10px;">
         <div class="sign-card">
-          <div class="sign-emoji">🔇</div>
-          <div class="sign-name">Absent Flow</div>
-          <div class="sign-desc">No color Doppler signal in affected testis vs normal contralateral — the most important finding. Absent = torsion until proven otherwise.</div>
+          <div class="sign-emoji">📏</div>
+          <div class="sign-name">Cortical Step-off</div>
+          <div class="sign-desc">Sharp discontinuity in the bright cortical line — even subtle &lt;1 mm break visible in good window. Compare with contralateral if doubt.</div>
         </div>
         <div class="sign-card">
-          <div class="sign-emoji">🌀</div>
-          <div class="sign-name">Whirlpool Sign</div>
-          <div class="sign-desc">Twisted spermatic cord seen on B-mode or color Doppler — "pinwheel" appearance at cord entry. Pathognomonic.</div>
+          <div class="sign-emoji">🩸</div>
+          <div class="sign-name">Subperiosteal Hematoma</div>
+          <div class="sign-desc">Hypoechoic/anechoic crescent collection along the cortex, often the first sign before obvious step-off. Common in toddler fx ("buckle").</div>
         </div>
         <div class="sign-card">
-          <div class="sign-emoji">🔶</div>
-          <div class="sign-name">Heterogeneous Echotexture</div>
-          <div class="sign-desc">Late finding — loss of normal homogeneous pattern indicates infarction/necrosis. Poor prognostic sign.</div>
+          <div class="sign-emoji">🔻</div>
+          <div class="sign-name">Femoral Nerve</div>
+          <div class="sign-desc">Hyperechoic <strong>triangular</strong> structure, lateral to femoral artery, deep to fascia iliaca, superficial to iliopsoas. "Honeycomb" appearance.</div>
         </div>
         <div class="sign-card">
           <div class="sign-emoji">💧</div>
-          <div class="sign-name">Reactive Hydrocele</div>
-          <div class="sign-desc">Anechoic fluid around testis — common in torsion, epididymo-orchitis. Not specific but often present.</div>
+          <div class="sign-name">Local Anesthetic Spread</div>
+          <div class="sign-desc">Anechoic "lens" or "fluid stripe" spreading laterally to medially under fascia iliaca. If you see superficial bulge above fascia → wrong plane.</div>
         </div>
       </div>
       <div class="card-orange" style="padding:10px 14px;">
-        <h3>Torsion of Appendix Testis</h3>
+        <h3>Local Anesthetic Dosing (PEDS)</h3>
         <ul style="margin-top:6px;">
-          <li>Small hyperechoic nodule near epididymal head</li>
-          <li><strong>"Blue dot sign"</strong> on exam (pathognomonic if seen)</li>
-          <li>Normal testicular flow on Doppler</li>
-          <li>Treatment: NSAIDs, supportive care (self-limiting)</li>
+          <li><strong>Ropivacaine 0.2%</strong>: 0.5 mL/kg (max 3 mg/kg = 1.5 mL/kg of 0.2%)</li>
+          <li><strong>Bupivacaine 0.25%</strong>: 0.5 mL/kg (max 2 mg/kg)</li>
+          <li>Onset 15–30 min · Duration 4–8 hours</li>
+          <li>Always calculate <em>max</em> weight-based dose BEFORE drawing up</li>
         </ul>
       </div>
       <div class="pearl">
-        <strong>Pearl:</strong> Always compare bilaterally with identical Doppler settings. Asymmetric flow — even if some flow present — is abnormal and warrants urgent urology consultation.
+        <strong>Pearl — "Bow tie" landmark:</strong> The transition between sartorius (superior) and iliopsoas (inferior) under fascia iliaca creates a bow-tie shape; inject just under fascia at this junction for ideal spread.
       </div>
       <div class="pearl">
-        <strong>Pearl:</strong> The whirlpool sign (twisted cord) can sometimes be seen in B-mode — always scan the cord. Its absence does not exclude torsion.
+        <strong>Pearl — Hydrodissection:</strong> Use 1–2 mL of normal saline first to open the fascia iliaca plane safely before injecting local anesthetic. Confirms correct plane and avoids intraneural injection.
       </div>
       <div class="pitfall">
-        <strong>Pitfall:</strong> "Present flow" does not exclude torsion. Partial torsion (&lt;360°) or early/intermittent torsion may have preserved flow. Treat the patient, not the image.
+        <strong>Pitfall — LAST (Local Anesthetic Systemic Toxicity):</strong> CNS sx (perioral numbness, tinnitus, agitation, seizure) → cardiac (bradycardia → asystole). <strong>Lipid emulsion 20% 1.5 mL/kg bolus</strong>, ACLS, call for help. Never exceed weight-based max dose.
       </div>
       <div class="pitfall">
-        <strong>Pitfall:</strong> Epididymo-orchitis shows <strong>increased</strong> flow (hyperemia). If you see hyperperfusion = NOT torsion (but confirm with clinical picture and consider both diagnoses co-existing in teens — uncommon but possible).
+        <strong>Pitfall — Intravascular injection:</strong> ALWAYS aspirate before and during injection. Visualize needle tip throughout. The femoral artery is a few mm medial — careful with lateral approach.
       </div>
       <div class="card-green">
         <h4>Disposition</h4>
-        <p>Urology emergency consult immediately · NPO · IV access · Analgesia · Informed consent for bilateral orchiopexy (bell-clapper repairs both sides) · If no urologist available: manual detorsion "open the book" lateral-to-medial + transfer</p>
+        <p>Reassess in 15–20 min — pain ↓, allows splinting and X-ray. IV access + maintenance fluids. Ortho consult. Consider <strong>traction or hip spica</strong> for definitive management based on age + fx pattern. Document neurovascular exam pre- AND post-block. Admit for pain control / surgical fixation per ortho.</p>
       </div>
     </div>
   </div>
 </div>
 
 <!-- ═══════════════════════════════════════════
-     SLIDE 17 — CASE 6 DIVIDER
+     SLIDE 17 — CASE 6 DIVIDER · POSITIVE FAST
 ══════════════════════════════════════════════ -->
 <div class="slide section-slide">
   <span class="case-tag tag-trauma">Case 6 · Trauma</span>
   <div class="case-number-big" style="background: linear-gradient(135deg, var(--red) 0%, rgba(248,81,73,0.2) 100%); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text;">06</div>
-  <h2 style="margin-top:8px; font-size:clamp(24px,4vw,48px);">eFAST Exam</h2>
-  <p class="lead" style="margin-top:8px;">"Ultrasound in resuscitation is the rule, not the exception"</p>
+  <h2 style="margin-top:8px; font-size:clamp(24px,4vw,48px);">Positive FAST: Ped v. MVC</h2>
+  <p class="lead" style="margin-top:8px;">"Free fluid in the unstable child — find it fast, fix it faster"</p>
 </div>
 
 <!-- ═══════════════════════════════════════════
      SLIDE 18 — CASE 6 HISTORY
 ══════════════════════════════════════════════ -->
 <div class="slide">
-  <span class="case-tag tag-trauma">Case 6 · Trauma — eFAST Exam</span>
+  <span class="case-tag tag-trauma">Case 6 · Trauma — Pedestrian vs MVC</span>
   <h2 style="margin-bottom:14px;">Clinical Presentation</h2>
   <div class="col-6040">
     <div class="stack">
       <div class="card">
         <h3>History</h3>
         <ul style="margin-top:6px;">
-          <li><strong>16-year-old male</strong>, unrestrained rear passenger</li>
-          <li>High-speed MVC, T-bone collision, airbag deployed</li>
-          <li>EMS: GCS 13 at scene, now 14 in ED</li>
-          <li>Complaining of abdominal and chest pain</li>
-          <li>No obvious external hemorrhage</li>
-          <li>Pelvis stable on exam</li>
+          <li><strong>10-year-old male</strong>, pedestrian struck by sedan ~30 mph</li>
+          <li>Thrown ~15 ft, lateral impact on R side; brief LOC at scene</li>
+          <li>EMS report: c-spine immobilized, 2 PIVs, 250 mL NS en route</li>
+          <li>Trauma activation; arrived 18 min after injury</li>
+          <li>Bystander CPR not required, no overt external hemorrhage</li>
+          <li>NPO since school lunch</li>
         </ul>
       </div>
       <div class="card-accent">
         <h3>Primary Survey (Trauma Bay)</h3>
         <ul style="margin-top:6px;">
-          <li>A: Patent, C-collar in place</li>
-          <li>B: Tachypneic RR 28, SpO₂ 96%, decreased L breath sounds</li>
-          <li>C: <strong>HR 138, BP 88/58, cool clammy skin</strong>, cap refill 4s</li>
-          <li>D: GCS 14, pupils equal and reactive</li>
-          <li>E: Seatbelt sign across abdomen, multiple abrasions</li>
+          <li><strong>A:</strong> Patent · talking · C-collar in place</li>
+          <li><strong>B:</strong> RR 32, shallow; SpO₂ 94% RA; decreased breath sounds L</li>
+          <li><strong>C:</strong> <strong>HR 156, BP 88/52</strong>, narrow pulse pressure, cool extremities, cap refill 4 sec; faint distal pulses</li>
+          <li><strong>D:</strong> GCS 13 (E3 V4 M6), pupils 3 mm equal reactive</li>
+          <li><strong>E:</strong> "Waddell's triad" suspected — R thigh ecchymosis (femur), L flank abrasion, scalp hematoma</li>
         </ul>
       </div>
       <div class="card-red">
-        <h4>🚨 Hemodynamically Unstable</h4>
-        <p>Shock index (HR/SBP) = <strong>1.57</strong> — high hemorrhage risk. eFAST is the <strong>first test</strong> — faster than CT.</p>
+        <h4>🚨 Pediatric Compensated Shock</h4>
+        <p>Shock index pediatric-adjusted (SIPA) age 6–12: <strong>HR/SBP &gt;1.22</strong> = high risk. This patient = 1.77. <em>Children compensate with tachycardia until they crash.</em></p>
       </div>
     </div>
     <div class="stack">
       <div class="card-teal">
-        <h3>Why eFAST Changes Everything</h3>
-        <p style="margin-top:6px;">In pediatric trauma, positive eFAST + hemodynamic instability = hemorrhagic shock until proven otherwise. <strong>No time for CT.</strong></p>
+        <h3>Why eFAST Now (Not CT)</h3>
+        <p style="margin-top:6px;">Hemodynamically unstable child + abdominal mechanism = bedside eFAST in seconds, before transport. Positive + unstable → <strong>OR / massive transfusion</strong>, not CT.</p>
         <div style="margin-top:10px;" class="measure-grid">
           <div class="measure-item">
             <div class="measure-value">~73%</div>
-            <div class="measure-label">Sensitivity (hemoperitoneum)</div>
+            <div class="measure-label">Sens (hemoperitoneum)</div>
           </div>
           <div class="measure-item">
             <div class="measure-value">~94%</div>
             <div class="measure-label">Specificity</div>
           </div>
+          <div class="measure-item">
+            <div class="measure-value">95%+</div>
+            <div class="measure-label">PPV if unstable</div>
+          </div>
         </div>
-        <p class="small" style="margin-top:6px;">Negative eFAST does NOT rule out injury (solid organ injury may not free-bleed initially). Serial eFAST every 30 min if concern persists.</p>
+        <p class="small" style="margin-top:6px;">Negative eFAST in <em>stable</em> child does NOT rule out solid organ injury — CT remains standard for definitive evaluation.</p>
       </div>
       <div class="card-accent">
-        <h4>eFAST Views (6 total)</h4>
+        <h4>The "Six Views" of eFAST</h4>
         <ul class="no-bullet">
-          <li>RUQ — Morrison's pouch (hepatorenal)</li>
-          <li>LUQ — Splenorenal</li>
-          <li>Pelvis — Pouch of Douglas / rectovesical</li>
-          <li>Subxiphoid — Pericardial</li>
-          <li>R chest — Pneumothorax / hemothorax</li>
-          <li>L chest — Pneumothorax / hemothorax</li>
+          <li><strong>RUQ</strong> — Morison's pouch (hepatorenal)</li>
+          <li><strong>LUQ</strong> — Splenorenal recess + subdiaphragm</li>
+          <li><strong>Pelvis</strong> — Rectovesical / Pouch of Douglas</li>
+          <li><strong>Subxiphoid</strong> — Pericardial effusion</li>
+          <li><strong>R + L Chest</strong> — PTX (anterior) + hemothorax (basal)</li>
         </ul>
       </div>
       <div class="card-yellow">
-        <h4>Pediatric Differences</h4>
-        <p class="small">Children compensate longer → BP drops late. Liver and spleen proportionally larger and less protected. Solid organ injury more common than hollow viscus. Seatbelt sign = 10× risk of hollow viscus injury.</p>
+        <h4>Pediatric Specifics</h4>
+        <p class="small">Spleen + liver proportionally larger, ribs more compliant → solid organ injury without rib fracture is common. Seatbelt/handlebar sign: 10× risk of hollow viscus injury. Pelvic injuries less common but more likely to bleed catastrophically.</p>
       </div>
     </div>
   </div>
@@ -1496,7 +1477,7 @@
      SLIDE 19 — CASE 6 ULTRASOUND
 ══════════════════════════════════════════════ -->
 <div class="slide">
-  <span class="case-tag tag-trauma">Case 6 · Trauma — eFAST Exam</span>
+  <span class="case-tag tag-trauma">Case 6 · Trauma — Positive FAST</span>
   <h2 style="margin-bottom:14px;">Ultrasound Technique &amp; Findings</h2>
   <div class="cols-2">
     <div class="stack scroll-inner">
@@ -1504,26 +1485,29 @@
         <div class="probe-icon">🔬</div>
         <div>
           <h4>Probe &amp; Settings</h4>
-          <p><strong>Curvilinear</strong> 2–5 MHz (abdomen) · <strong>Phased array</strong> (cardiac/subxiphoid) · <strong>Linear</strong> (chest — PTX)</p>
-          <p class="small">No special setting. Depth: start at 12–16 cm, adjust per view.</p>
+          <p><strong>Curvilinear</strong> 2–5 MHz (abdomen) · <strong>Phased array</strong> for subxiphoid/cardiac · <strong>Linear</strong> 5–12 MHz for chest (PTX)</p>
+          <p class="small">FAST/Abdominal preset · Depth 12–16 cm (adolescent), 8–12 cm (school-age) · Goal: full exam in &lt;2 min</p>
         </div>
       </div>
       <div class="card">
-        <h3>Systematic Approach (Goal: &lt;2 min)</h3>
+        <h3>Systematic 6-View Approach</h3>
         <div class="algo-step"><div class="algo-num">1</div>
-          <div><p><strong>RUQ — Morison's Pouch</strong></p><p class="small">Coronal view, mid-axillary line R. Look in hepatorenal space, subphrenic, around gallbladder. Most sensitive for hemoperitoneum.</p></div>
+          <div><p><strong>RUQ — Morison's Pouch</strong> <span class="badge badge-red">positive in our pt</span></p><p class="small">Probe coronal, mid-axillary line R, marker cephalad. Fan through hepatorenal space, subdiaphragm above liver, and inferior tip of liver. <em>Most sensitive single view.</em></p></div>
         </div>
         <div class="algo-step"><div class="algo-num">2</div>
-          <div><p><strong>LUQ — Splenorenal</strong></p><p class="small">More posterior than RUQ. Fan superior (subphrenic), inferior (splenorenal), check for free fluid. Harder due to posterior position.</p></div>
+          <div><p><strong>LUQ — Splenorenal/Subdiaphragm</strong></p><p class="small">Probe more <em>posterior + cephalad</em> than RUQ ("knuckles to bed"). Fluid collects subdiaphragmatic first, then splenorenal. Spleen smaller window → easy to miss.</p></div>
         </div>
         <div class="algo-step"><div class="algo-num">3</div>
-          <div><p><strong>Pelvis — Suprapubic</strong></p><p class="small">Transverse and longitudinal above bladder. Free fluid collects posterior/superior to bladder (POD or rectovesical pouch). Full bladder helps.</p></div>
+          <div><p><strong>Pelvis — Suprapubic</strong></p><p class="small">Transverse + sagittal above pubis. Free fluid posterior/superior to bladder (rectovesical pouch males / POD females). Full bladder = acoustic window.</p></div>
         </div>
         <div class="algo-step"><div class="algo-num">4</div>
-          <div><p><strong>Subxiphoid — Cardiac</strong></p><p class="small">Subcostal 4-chamber. Pericardial effusion = dark stripe around heart. Tamponade physiology: RV collapse in diastole.</p></div>
+          <div><p><strong>Subxiphoid Cardiac</strong></p><p class="small">Probe flat, aim L shoulder, use liver as window. Pericardial effusion = dark stripe between heart and pericardium. Look for RV diastolic collapse.</p></div>
         </div>
         <div class="algo-step"><div class="algo-num">5</div>
-          <div><p><strong>Bilateral Chest — PTX/Hemothorax</strong></p><p class="small">Linear probe, 2nd ICS MCL. Absent sliding + absent B-lines + lung point = PTX. Hemothorax: anechoic fluid above diaphragm, compressed lung.</p></div>
+          <div><p><strong>Bilateral Anterior Chest — PTX</strong></p><p class="small">Linear probe, 2nd–3rd ICS MCL. Confirm <strong>bat sign</strong>, look for sliding/B-lines. If no sliding → M-mode, look for lung point.</p></div>
+        </div>
+        <div class="algo-step"><div class="algo-num">6</div>
+          <div><p><strong>Posterior Basal Lung — Hemothorax</strong></p><p class="small">Same RUQ/LUQ view, fan cephalad over diaphragm. Anechoic fluid <em>above</em> diaphragm with "spine sign" (spine visible above diaphragm into thorax) = hemothorax.</p></div>
         </div>
       </div>
     </div>
@@ -1531,57 +1515,51 @@
       <div class="cols-2" style="flex:unset; grid-template-columns:1fr 1fr; gap:10px;">
         <div class="sign-card">
           <div class="sign-emoji">🩸</div>
-          <div class="sign-name">Free Fluid</div>
-          <div class="sign-desc">Anechoic (early) or echogenic (clotted) fluid in dependent spaces. Even a thin 5mm stripe = significant volume.</div>
+          <div class="sign-name">Free Fluid (RUQ)</div>
+          <div class="sign-desc">Anechoic stripe in Morison's pouch between liver and kidney. <strong>Even 1 mm stripe</strong> is abnormal in trauma. In our patient: ~1 cm crescent + subdiaphragmatic fluid.</div>
+        </div>
+        <div class="sign-card">
+          <div class="sign-emoji">🌫️</div>
+          <div class="sign-name">Spine Sign</div>
+          <div class="sign-desc">In RUQ/LUQ, the thoracic spine becomes visible above the diaphragm when fluid (hemothorax) replaces normal air. Normal lung obscures spine due to air.</div>
         </div>
         <div class="sign-card">
           <div class="sign-emoji">❤️</div>
-          <div class="sign-name">Tamponade</div>
-          <div class="sign-desc">Pericardial effusion + RV collapse during diastole + IVC plethora. Physiologic tamponade = immediate pericardiocentesis.</div>
+          <div class="sign-name">Pericardial Effusion</div>
+          <div class="sign-desc">Anechoic rim around heart on subxiphoid view. ANY effusion in penetrating trauma = OR. Blunt: assess for tamponade physiology.</div>
         </div>
         <div class="sign-card">
-          <div class="sign-emoji">💨</div>
-          <div class="sign-name">Pneumothorax</div>
-          <div class="sign-desc">Absent lung sliding + absent B-lines + "barcode sign" on M-mode + lung point (specific). Sensitivity ~86–98%.</div>
-        </div>
-        <div class="sign-card">
-          <div class="sign-emoji">🔴</div>
-          <div class="sign-name">Hemothorax</div>
-          <div class="sign-desc">Anechoic/hypoechoic fluid above diaphragm. Look in thoracic views and also LUQ/RUQ for subphrenic fluid.</div>
+          <div class="sign-emoji">📍</div>
+          <div class="sign-name">Lung Point</div>
+          <div class="sign-desc">Transition between sliding and absent sliding pleura = pneumothorax. 100% specific. Mid-axillary lung point = large PTX.</div>
         </div>
       </div>
       <div class="card-red" style="padding:10px 14px;">
-        <h3>Semi-Quantitative Free Fluid Score</h3>
-        <div style="display:grid; grid-template-columns:1fr 1fr 1fr; gap:8px; margin-top:8px;">
-          <div style="text-align:center; padding:8px; background:rgba(63,185,80,0.1); border-radius:8px;">
-            <div style="font-size:18px; font-weight:800; color:var(--green);">0</div>
-            <div class="small">No fluid</div>
-          </div>
-          <div style="text-align:center; padding:8px; background:rgba(210,153,34,0.1); border-radius:8px;">
-            <div style="font-size:18px; font-weight:800; color:var(--yellow);">1–2</div>
-            <div class="small">Small (&lt;1 cm stripe) · Consider CT if stable</div>
-          </div>
-          <div style="text-align:center; padding:8px; background:rgba(248,81,73,0.1); border-radius:8px;">
-            <div style="font-size:18px; font-weight:800; color:var(--red);">3+</div>
-            <div class="small">Large (clot, multiple spaces) · OR if unstable</div>
-          </div>
-        </div>
+        <h3>This Patient's eFAST</h3>
+        <ul style="margin-top:6px;">
+          <li><strong>RUQ:</strong> POSITIVE — 1 cm anechoic stripe in Morison's pouch + subdiaphragmatic fluid (likely hepatic laceration)</li>
+          <li><strong>LUQ:</strong> POSITIVE — splenorenal free fluid (concern for splenic injury)</li>
+          <li><strong>Pelvis:</strong> Trace free fluid posterior to bladder</li>
+          <li><strong>Subxiphoid:</strong> No pericardial effusion</li>
+          <li><strong>L Chest:</strong> Absent sliding + lung point at anterior axillary line → <strong>traumatic PTX</strong></li>
+          <li><strong>R Chest:</strong> Normal lung sliding + A-lines</li>
+        </ul>
       </div>
       <div class="pearl">
-        <strong>Pearl:</strong> Perinephric fat can mimic free fluid. Fat is slightly echogenic, does not shift with position change, and has no sharp border with the kidney.
+        <strong>Pearl — Trendelenburg trick:</strong> If you suspect free fluid but Morison's pouch looks clean, tilt the patient slightly head-down (if c-spine cleared) — fluid migrates cephalad and the stripe becomes more apparent. Even small repositioning reveals occult fluid.
       </div>
       <div class="pearl">
-        <strong>Pearl:</strong> The liver is your best friend in RUQ — identify it first, then the kidney below, then look in the space between them (Morison's pouch). Even 1mm of fluid here is significant.
+        <strong>Pearl — Serial scans win:</strong> A single negative FAST has limited NPV in peds. If clinical concern persists or hemodynamics worsen, REPEAT in 15–30 min — bleeding may accumulate over time. Serial FAST sens approaches 90%.
       </div>
       <div class="pitfall">
-        <strong>Pitfall:</strong> Ascites in a trauma patient — free fluid doesn't always mean hemorrhage. Look for echogenicity (blood = variable, exudate = echogenic swirling). Clinical context is everything.
+        <strong>Pitfall — Perinephric fat / epicardial fat / ascites:</strong> Fat = mildly echogenic, no fluid level, no shifting. Pre-existing ascites is uncommon in healthy peds but possible (nephrotic syndrome, oncology). Always check echogenicity and look at clinical context.
       </div>
       <div class="pitfall">
-        <strong>Pitfall:</strong> Negative FAST in hemodynamic instability ≠ no intra-abdominal injury. Retroperitoneal hematoma, early solid organ injury, mesenteric tears won't show on FAST. Repeat and escalate.
+        <strong>Pitfall — Retroperitoneal blood is INVISIBLE on FAST.</strong> Pelvic fractures, renal injuries, duodenal hematomas may bleed posteriorly and never show as intraperitoneal fluid. Unexplained instability + negative FAST = consider retroperitoneal bleed → CT or OR.
       </div>
       <div class="card-green">
-        <h4>Decision Algorithm</h4>
-        <p><strong>Positive FAST + unstable</strong> → OR (hemorrhage control) · <strong>Positive FAST + stable</strong> → CT abdomen/pelvis with contrast · <strong>Negative FAST + unstable</strong> → Repeat FAST, consider DPL, re-examine, or empiric laparotomy</p>
+        <h4>Disposition — Our Patient (Positive FAST + Unstable)</h4>
+        <p><strong>Activate massive transfusion protocol</strong> (1:1:1) · Pediatric trauma surgery to bedside · Direct to OR for exploratory laparotomy + L chest tube · TXA per pediatric trauma protocol if &lt;3 hr from injury · NPO · Type &amp; cross · CT only if stabilized post-op and ongoing concern for occult injury · Anticipate hypothermia, acidosis, coagulopathy (lethal triad).</p>
       </div>
     </div>
   </div>
@@ -1592,52 +1570,52 @@
 ══════════════════════════════════════════════ -->
 <div class="slide">
   <span class="case-tag tag-title">Summary</span>
-  <h2 style="margin-bottom:16px;">Key Takeaways</h2>
+  <h2 style="margin-bottom:16px;">Key Takeaways — All 6 Cases</h2>
   <div class="cols-3" style="gap:14px;">
     <div class="card-teal stack" style="gap:8px;">
-      <span class="case-tag tag-pem" style="margin-bottom:0;">PEM Cases</span>
+      <span class="case-tag tag-pem" style="margin-bottom:0;">PEM Cases (1–4)</span>
       <div>
-        <p><strong>Pyloric Stenosis:</strong> Muscle ≥4mm · Cervix sign · Correct lytes before OR</p>
+        <p><strong>Biliary Sludge:</strong> Curvilinear · WES sign · sludge shifts with positioning · think SCD &amp; ceftriaxone</p>
       </div>
       <hr>
       <div>
-        <p><strong>Intussusception:</strong> Target/pseudokidney sign · Doppler predicts reduction success</p>
+        <p><strong>Intussusception:</strong> Target/pseudokidney sign · ≥3 cm = pathologic · Doppler predicts reduction success</p>
       </div>
       <hr>
       <div>
-        <p><strong>Appendicitis:</strong> Graded compression · ≥6mm outer wall · PAS score guides US-first pathway</p>
+        <p><strong>Pneumothorax:</strong> 3-step algorithm: absent sliding + no B-lines + lung point (100% specific) · turn harmonics OFF</p>
       </div>
       <hr>
       <div>
-        <p><strong>Lung US:</strong> B-lines · Dynamic air bronchograms · Assess effusion character</p>
+        <p><strong>Cardiac:</strong> 5 questions · PSLA effusion passes anterior to descending aorta · RV diastolic collapse = tamponade</p>
       </div>
     </div>
     <div class="card-orange stack" style="gap:8px;">
-      <span class="case-tag tag-urology" style="margin-bottom:0;">Testicular Torsion</span>
-      <p>Always compare bilateral flow. Absent flow = OR. Don't let a "normal" POCUS delay urology consult if clinical suspicion is high.</p>
+      <span class="case-tag tag-urology" style="margin-bottom:0;">Case 5 · Femur Fx + FICB</span>
+      <p>POCUS finds occult cortical fx · FICB = opioid-sparing pain control · inject under fascia iliaca, above iliopsoas, lateral to femoral artery.</p>
       <hr>
       <div class="measure-grid" style="grid-template-columns:1fr 1fr; gap:8px;">
         <div class="measure-item">
-          <div class="measure-value" style="color:var(--green); font-size:20px;">&gt;90%</div>
-          <div class="measure-label">Salvage &lt;6h</div>
+          <div class="measure-value" style="color:var(--teal); font-size:18px;">2 pops</div>
+          <div class="measure-label">fascia lata + iliaca</div>
         </div>
         <div class="measure-item">
-          <div class="measure-value" style="color:var(--red); font-size:20px;">&lt;10%</div>
-          <div class="measure-label">Salvage &gt;24h</div>
+          <div class="measure-value" style="color:var(--green); font-size:18px;">6 hr</div>
+          <div class="measure-label">block duration</div>
         </div>
       </div>
-      <p class="small">Whirlpool sign = pathognomonic. Bell-clapper = bilateral risk.</p>
+      <p class="small">Aspirate first · weight-based dose · watch for LAST · always reassess neurovasc post-block.</p>
     </div>
     <div class="card-red stack" style="gap:8px;">
-      <span class="case-tag tag-trauma" style="margin-bottom:0;">eFAST</span>
-      <p>6 views. Goal &lt;2 minutes. Positive + unstable = OR. Negative does NOT rule out injury.</p>
+      <span class="case-tag tag-trauma" style="margin-bottom:0;">Case 6 · Positive FAST</span>
+      <p>6 views &lt;2 min. <strong>Positive + unstable = OR</strong>. Serial scans win. Retroperitoneal blood is invisible on FAST.</p>
       <hr>
       <ul class="no-bullet" style="font-size:13px;">
-        <li>RUQ most sensitive</li>
-        <li>LUQ is most posterior</li>
-        <li>Pelvis needs full bladder</li>
-        <li>Lung point = specific for PTX</li>
-        <li>RV diastolic collapse = tamponade</li>
+        <li>RUQ Morison's = most sensitive</li>
+        <li>LUQ "knuckles to bed"</li>
+        <li>Spine sign = hemothorax</li>
+        <li>SIPA &gt;1.22 = high-risk shock</li>
+        <li>Lung point on chest = traumatic PTX</li>
       </ul>
     </div>
   </div>
@@ -1651,7 +1629,7 @@
         <span class="badge badge-green">Bilateral comparison</span>
         <span class="badge badge-yellow">Clinical + US together</span>
         <span class="badge badge-red">Negative ≠ excluded</span>
-        <span class="badge badge-purple">Graded compression</span>
+        <span class="badge badge-purple">Image both planes</span>
         <span class="badge badge-orange">Serial exams if uncertain</span>
       </div>
     </div>
@@ -1667,11 +1645,11 @@
   <div class="cols-2">
     <div class="stack">
       <div class="card">
-        <h4>Pyloric Stenosis</h4>
+        <h4>Biliary / Gallbladder Sludge</h4>
         <ul style="margin-top:6px;">
-          <li class="small">Hernanz-Schulman M. Pyloric stenosis: role of imaging. <em>Pediatr Radiol</em> 2009</li>
-          <li class="small">Blumhagen JD et al. Sonographic diagnosis of HPS. <em>AJR</em> 1988</li>
-          <li class="small">Maheshwai P et al. Pyloric stenosis US criteria. <em>J Pediatr Surg</em> 2014</li>
+          <li class="small">Summers SM et al. ED POCUS for cholecystitis. <em>Ann Emerg Med</em> 2010</li>
+          <li class="small">Walsh P et al. Biliary disease in pediatric sickle cell. <em>J Pediatr</em> 2016</li>
+          <li class="small">Bode CO et al. Ceftriaxone-associated biliary pseudolithiasis in children. <em>Eur J Pediatr</em> 2002</li>
         </ul>
       </div>
       <div class="card">
@@ -1683,36 +1661,36 @@
         </ul>
       </div>
       <div class="card">
-        <h4>Appendicitis</h4>
+        <h4>Pneumothorax</h4>
         <ul style="margin-top:6px;">
-          <li class="small">Samuel M. Pediatric appendicitis score. <em>J Pediatr Surg</em> 2002</li>
-          <li class="small">Doria AS et al. US vs CT for appendicitis. <em>Radiology</em> 2006</li>
-          <li class="small">Kharbanda AB et al. US-first pathway. <em>Pediatrics</em> 2020</li>
+          <li class="small">Lichtenstein DA, Mezière GA. BLUE protocol — lung US in acute respiratory failure. <em>Chest</em> 2008</li>
+          <li class="small">Alrajhi K et al. Test characteristics of US for PTX. <em>Chest</em> 2012 (meta-analysis)</li>
+          <li class="small">Volpicelli G et al. Intl consensus statement on point-of-care lung US. <em>Intensive Care Med</em> 2012</li>
         </ul>
       </div>
       <div class="card">
-        <h4>Lung Ultrasound</h4>
+        <h4>Cardiac POCUS</h4>
         <ul style="margin-top:6px;">
-          <li class="small">Lichtenstein DA. BLUE protocol. <em>Chest</em> 2008</li>
-          <li class="small">Pereda MA et al. LUS for community-acquired pneumonia in children. <em>Pediatrics</em> 2015 (meta-analysis)</li>
-          <li class="small">Volpicelli G et al. International consensus statement on LUS. <em>Intensive Care Med</em> 2012</li>
+          <li class="small">Mandavia DP et al. ED echocardiography for pericardial effusion. <em>Ann Emerg Med</em> 2001</li>
+          <li class="small">Spurney CF et al. POCUS in pediatric heart failure. <em>Pediatr Crit Care Med</em> 2005</li>
+          <li class="small">Tsung JW et al. Bedside echo in suspected pediatric myocarditis. <em>Pediatr Emerg Care</em> 2014</li>
         </ul>
       </div>
     </div>
     <div class="stack">
       <div class="card">
-        <h4>Testicular Torsion</h4>
+        <h4>Femur Fracture / Fascia Iliaca Block</h4>
         <ul style="margin-top:6px;">
-          <li class="small">Frush DP et al. US of testicular torsion. <em>Radiol Clin North Am</em> 2006</li>
-          <li class="small">Baud C et al. Whirlpool sign in testicular torsion. <em>Pediatr Radiol</em> 1998</li>
-          <li class="small">Yagil Y et al. Doppler US in testicular torsion. <em>J Ultrasound Med</em> 2010</li>
+          <li class="small">Weinberg ER et al. US for diagnosis of long-bone fx in children. <em>Pediatr Emerg Care</em> 2010</li>
+          <li class="small">Frenkel O et al. US-guided FICB in pediatric femur fx. <em>Ann Emerg Med</em> 2012</li>
+          <li class="small">Neal JM et al. ASRA practice advisory on LAST. <em>Reg Anesth Pain Med</em> 2018</li>
         </ul>
       </div>
       <div class="card">
-        <h4>eFAST</h4>
+        <h4>eFAST in Pediatric Trauma</h4>
         <ul style="margin-top:6px;">
-          <li class="small">Rozycki GS et al. FAST in trauma. <em>Ann Surg</em> 1998</li>
-          <li class="small">Holmes JF et al. FAST in pediatric blunt abdominal trauma. <em>Ann Emerg Med</em> 2012</li>
+          <li class="small">Holmes JF et al. FAST in pediatric blunt abdominal trauma — RCT. <em>JAMA</em> 2017</li>
+          <li class="small">Acker SN et al. Pediatric SIPA — shock index. <em>J Pediatr Surg</em> 2017</li>
           <li class="small">Montoya J et al. eFAST including pneumothorax. <em>J Trauma</em> 2016</li>
         </ul>
       </div>
@@ -1724,13 +1702,13 @@
           <li>Ultrasound Podcast (ultrasoundpodcast.com)</li>
           <li>Core Ultrasound (core-ultrasound.com)</li>
           <li>5MinSono (5minsono.com)</li>
-          <li>SAEM POCUS Interest Group resources</li>
+          <li>SAEM POCUS Interest Group · P²Network · PEMNetwork</li>
         </ul>
       </div>
       <div class="card-accent" style="text-align:center; padding:20px;">
         <p style="font-size:28px; margin-bottom:8px;">🎉</p>
-        <h3>Great session!</h3>
-        <p class="small" style="margin-top:4px;">Questions? Scan review? Schedule next Pass the Pointer?</p>
+        <h3>Pass the Pointer!</h3>
+        <p class="small" style="margin-top:4px;">Questions? Scan review? Bring your clips and let's correlate next month.</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary

Refreshes the Pass the Pointer POCUS deck (`pocus-presentation.html`) with the 6 cases ultrasounded this month for the May 2026 PEM session — 4 PEM-focused + 2 procedural/trauma.

### Cases
1. **Biliary Sludge (PEM)** — 15 y/o SCD, RUQ pain after meals · GB anatomy, WES sign, sonographic Murphy's, ceftriaxone pseudolithiasis
2. **Intussusception (PEM)** — 18-month-old, colicky pain · Target/pseudokidney sign, Doppler for reduction success
3. **Pneumothorax (PEM)** — 17 y/o tall thin male, primary spontaneous · 3-step LUS algorithm, lung point (100% specific)
4. **Cardiac (PEM)** — 12 y/o post-viral myocarditis + effusion · 4 standard views, RV diastolic collapse, EPSS, IVC
5. **Femur Fracture + FICB (MSK/Procedural)** — 5 y/o playground fall · Cortical disruption + US-guided fascia iliaca block
6. **Positive FAST (Trauma)** — 10 y/o pedestrian struck by MVC · 6-view eFAST with positive findings + traumatic PTX

### What changed
- Title slide case grid, case-thumb labels and links
- Format/timeline slide (case names + times)
- Cases 1, 3, 4 fully replaced (Pyloric Stenosis → Biliary Sludge; Appendicitis → Pneumothorax; Lung US → Cardiac)
- Case 5 retooled (Testicular Torsion → Femur Fx + FICB, retains orange tag styling)
- Case 6 refreshed (eFAST → Positive FAST for ped v. MVC scenario)
- Summary + References updated to match
- Slide template, CSS, and JS navigation/timer preserved

## Test plan
- [ ] Open `pocus-presentation.html` in a browser
- [ ] Confirm 22 slides render (1 title, 1 format, 6×3 case slides, 1 summary, 1 references)
- [ ] Navigate with arrow keys and case-thumb clicks
- [ ] Start the 45-min timer (T key)
- [ ] Verify each case divider → history → ultrasound flow


---
_Generated by [Claude Code](https://claude.ai/code/session_018sMKmSihrttFhJVjy8BZyF)_