### PR TITLE
PALS sim: random patient, mobile-accessible HUD, cel-shaded visuals

### DIFF
--- a/code-simulator.css
+++ b/code-simulator.css
@@ -80,6 +80,31 @@ html, body {
 .scn-doses { display: flex; flex-wrap: wrap; gap: 6px 14px; font-size: 0.82rem; color: #cdeee7; margin: 8px 0; }
 .scn-doses b { color: var(--bright); }
 .scn-go { display: inline-block; margin-top: 6px; font-weight: 900; color: var(--bright); }
+
+.setup-main-head {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 14px; flex-wrap: wrap; margin-bottom: 14px;
+}
+.setup-main-head h2 { margin: 0; }
+.random-btn {
+  font-family: inherit; font-weight: 900; font-size: 0.95rem;
+  background: linear-gradient(135deg, var(--bright), #6fe3c2);
+  color: #06231f; border: none; border-radius: 30px;
+  padding: 11px 20px; cursor: pointer; box-shadow: 0 4px 0 var(--shadow);
+  transition: transform 0.1s, filter 0.1s;
+}
+.random-btn:hover { filter: brightness(1.06); }
+.random-btn:active { transform: translateY(2px); box-shadow: 0 2px 0 var(--shadow); }
+.scn-card.scn-chosen {
+  border-color: var(--bright);
+  background: rgba(36, 166, 135, 0.2);
+  animation: scn-flash 0.42s ease;
+}
+@keyframes scn-flash {
+  0% { transform: scale(1); box-shadow: 0 0 0 0 rgba(36,166,135,0.6); }
+  50% { transform: scale(1.03); box-shadow: 0 0 0 10px rgba(36,166,135,0); }
+  100% { transform: scale(1); }
+}
 .how-list { line-height: 1.5; color: #cdeee7; padding-left: 20px; }
 .how-list em { color: #fff; font-style: normal; font-weight: 800; }
 .mic-setup {
@@ -305,10 +330,80 @@ html, body {
   box-shadow: 0 4px 0 var(--shadow);
 }
 
-/* responsive */
-@media (max-width: 720px) {
-  .dose-card { width: 240px; font-size: 0.9rem; }
-  .monitor-mirror canvas { width: 240px; height: 141px; }
-  .action-rail { display: none; }
-  .log-panel { width: 60%; max-height: 26vh; bottom: 120px; }
+/* mobile panel-toggle tabs — hidden on desktop, where the panels are always
+   docked. On phones they open the dose card / record / action rail one at a
+   time as bottom sheets so the HUD never overlaps. */
+.panel-tabs { display: none; }
+
+/* ===================== RESPONSIVE / MOBILE ===================== */
+
+/* Tablet: keep the docked panels but shrink them so they stop colliding. */
+@media (max-width: 900px) {
+  .dose-card { width: 250px; font-size: 0.86rem; }
+  .monitor-mirror canvas { width: 260px; height: 152px; }
+  .action-rail { top: auto; bottom: 150px; width: 150px; }
+  .log-panel { width: 300px; max-height: 24vh; }
+}
+
+/* Phones: rebuild the HUD as docked tabs + bottom sheets. */
+@media (max-width: 640px) {
+  /* top bar: compact, single row that can scroll its stats */
+  .hud-top { gap: 10px; padding: 8px 10px calc(8px + env(safe-area-inset-bottom, 0px)); }
+  .timer-main span { font-size: 1.5rem; }
+  .timer-cycle span { font-size: 1.05rem; }
+  .stat-row { gap: 10px; order: 3; width: 100%; overflow-x: auto; }
+  .stat label { font-size: 0.55rem; }
+  .stat-val { font-size: 0.95rem; }
+  .mic-block { margin-left: auto; gap: 8px; }
+  .mic-meter-wrap { display: none !important; }
+  .hf { font-size: 0.78rem; }
+
+  /* keep the vital monitor mirror — it's the whole point — but smaller */
+  .monitor-mirror { top: auto; bottom: 188px; right: 8px; }
+  .monitor-mirror canvas { width: 168px; height: 98px; }
+
+  /* the three big panels become full-width bottom sheets, one at a time */
+  .dose-card, .log-panel, .action-rail {
+    display: none;
+    position: fixed; left: 8px; right: 8px; width: auto;
+    bottom: 196px; top: auto; max-height: 50vh; overflow-y: auto;
+    z-index: 9;
+  }
+  body.show-dose .dose-card,
+  body.show-log .log-panel,
+  body.show-actions .action-rail { display: block; animation: sheet-up 0.18s ease; }
+  @keyframes sheet-up { from { transform: translateY(14px); opacity: 0; } to { transform: translateY(0); opacity: 1; } }
+
+  .action-rail {
+    flex-direction: row; flex-wrap: wrap; gap: 8px;
+    background: rgba(12, 31, 29, 0.96); padding: 12px; border-radius: 14px;
+    border: 1px solid rgba(214, 238, 234, 0.18);
+  }
+  .action-rail button { flex: 1 1 44%; text-align: center; padding: 12px 8px; font-size: 0.88rem; }
+
+  /* the toggle tabs sit just above the command bar */
+  .panel-tabs {
+    display: flex; gap: 8px; bottom: 132px; left: 8px; right: 8px;
+    justify-content: stretch;
+  }
+  .panel-tabs button {
+    flex: 1; font-family: inherit; font-weight: 800; font-size: 0.82rem;
+    background: rgba(12, 31, 29, 0.9); color: #eafdf8;
+    border: 1px solid rgba(214, 238, 234, 0.22); border-radius: 12px;
+    padding: 10px 6px; cursor: pointer;
+  }
+  .panel-tabs button.active { background: var(--bright); border-color: var(--bright); color: #fff; }
+
+  /* command bar: talk button + input on one row, tools below, thumb-reachable */
+  .cmd-bar {
+    gap: 8px; padding: 10px 8px calc(10px + env(safe-area-inset-bottom, 0px));
+  }
+  .ptt { flex: 0 0 auto; padding: 14px 18px; font-size: 0.92rem; }
+  .cmd-form { order: 3; width: 100%; min-width: 0; }
+  .cmd-form input { font-size: 16px; padding: 12px; } /* 16px stops iOS zoom-on-focus */
+  .cmd-tools { margin-left: 0; }
+  .cmd-tools button { padding: 12px 14px; }
+
+  .mic-note { bottom: 196px; max-width: calc(100% - 16px); left: 8px; }
+  .help-panel { left: 8px; right: 8px; width: auto; bottom: 132px; }
 }

--- a/code-simulator.html
+++ b/code-simulator.html
@@ -37,7 +37,10 @@
 
     <div class="setup-grid">
       <div class="setup-main">
-        <h2>Choose your patient</h2>
+        <div class="setup-main-head">
+          <h2>Choose your patient</h2>
+          <button id="randomScenario" type="button" class="random-btn">🎲 Surprise me — random patient</button>
+        </div>
         <div id="scenarioGrid" class="scn-grid"></div>
       </div>
       <aside class="setup-aside">
@@ -117,6 +120,13 @@
       <button data-cmd="switch">Switch Compressor</button>
       <button data-cmd="reversible">H's &amp; T's</button>
       <button data-cmd="status">Status Recap</button>
+    </div>
+
+    <!-- mobile-only panel toggles (these panels are docked/hidden on phones) -->
+    <div class="hud panel-tabs">
+      <button type="button" data-panel="dose">💊 Doses</button>
+      <button type="button" data-panel="log">📋 Record</button>
+      <button type="button" data-panel="actions">⚡ Actions</button>
     </div>
 
     <!-- bottom command bar -->

--- a/code-simulator.js
+++ b/code-simulator.js
@@ -406,10 +406,18 @@ class Mic {
 class Scene3D {
   constructor(canvas) {
     this.canvas = canvas;
-    this.renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
-    this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
-    this.renderer.shadowMap.enabled = true;
+    // Phones / touch devices get the lighter path: no shadow maps, capped pixel
+    // ratio. The cel-shaded look (below) carries the scene without them.
+    this.lowPower =
+      window.matchMedia("(max-width: 820px)").matches ||
+      window.matchMedia("(pointer: coarse)").matches;
+    this.renderer = new THREE.WebGLRenderer({ canvas, antialias: !this.lowPower });
+    this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, this.lowPower ? 1.5 : 2));
+    this.renderer.shadowMap.enabled = !this.lowPower;
     this.renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+    // Cel-shading ramp: a few hard tone steps give the clean medical-illustration
+    // banding instead of soft photoreal gradients.
+    this.toonRamp = makeToonGradient();
     if ("outputColorSpace" in this.renderer) this.renderer.outputColorSpace = THREE.SRGBColorSpace;
     this.scene = new THREE.Scene();
     this.scene.background = new THREE.Color(0x0e1c22);
@@ -1197,10 +1205,56 @@ class Scene3D {
     this._ivPole();
     this._ventilator();
     this._mayoStand();
+    this._toonify();
+  }
+
+  /* Convert the standard PBR materials to cel-shaded (toon) ones in a single
+     post-build pass. Keeps the model geometry, role colors, and emissive cues
+     intact while swapping soft realism for a clean illustrated look that reads
+     better at small sizes and renders far cheaper on phones. Emissive/basic
+     materials (monitor screens, light lenses, sprites) are left untouched. */
+  _toonify() {
+    const seen = new Map();
+    this.scene.traverse((obj) => {
+      if (!obj.isMesh || !obj.material) return;
+      const swap = (mat) => {
+        if (!mat || !mat.isMeshStandardMaterial) return mat;
+        if (seen.has(mat)) return seen.get(mat);
+        const toon = new THREE.MeshToonMaterial({
+          color: mat.color.clone(),
+          map: mat.map || null,
+          gradientMap: this.toonRamp,
+          transparent: mat.transparent,
+          opacity: mat.opacity,
+          side: mat.side,
+          emissive: mat.emissive ? mat.emissive.clone() : new THREE.Color(0x000000),
+          emissiveIntensity: mat.emissiveIntensity ?? 1,
+        });
+        seen.set(mat, toon);
+        return toon;
+      };
+      obj.material = Array.isArray(obj.material)
+        ? obj.material.map(swap)
+        : swap(obj.material);
+    });
   }
 }
 
 /* --- Procedural textures / sprites for the bay --------------------------- */
+
+/* Cel-shading ramp for MeshToonMaterial. A handful of tone steps (not a smooth
+   gradient) is what gives the flat, illustrated medical look. The floor tone is
+   kept fairly light so shaded sides stay legible rather than going muddy. */
+function makeToonGradient() {
+  const steps = new Uint8Array([110, 165, 210, 245, 255]);
+  const tex = new THREE.DataTexture(steps, steps.length, 1, THREE.RedFormat);
+  tex.minFilter = THREE.NearestFilter;
+  tex.magFilter = THREE.NearestFilter;
+  tex.generateMipmaps = false;
+  tex.needsUpdate = true;
+  return tex;
+}
+
 function makeTileTexture() {
   const cv = document.createElement("canvas");
   cv.width = cv.height = 128;
@@ -2272,6 +2326,24 @@ class App {
       card.addEventListener("click", () => this.launch(sc));
       grid.appendChild(card);
     });
+
+    // "Surprise me" — pick a random scenario so learners can't pre-plan to a
+    // known rhythm/cause (closer to a real unannounced code).
+    const randBtn = document.getElementById("randomScenario");
+    if (randBtn) {
+      randBtn.addEventListener("click", () => {
+        const pick = SCENARIOS[Math.floor(Math.random() * SCENARIOS.length)];
+        // brief visual cue on the chosen card before launching
+        const cards = grid.querySelectorAll(".scn-card");
+        const idx = SCENARIOS.indexOf(pick);
+        const chosen = cards[idx];
+        if (chosen) {
+          chosen.classList.add("scn-chosen");
+          chosen.scrollIntoView({ behavior: "smooth", block: "nearest" });
+        }
+        setTimeout(() => this.launch(pick), chosen ? 420 : 0);
+      });
+    }
   }
 
   launch(scenario) {
@@ -2348,6 +2420,23 @@ class App {
     document.querySelectorAll("[data-cmd]").forEach((b) =>
       b.addEventListener("click", () => this.engine.handle({ id: b.dataset.cmd, raw: b.textContent }))
     );
+
+    // mobile panel toggles — on phones the dose card / record / action rail
+    // are hidden by default and surfaced one at a time as bottom sheets.
+    document.querySelectorAll(".panel-tabs [data-panel]").forEach((btn) => {
+      btn.addEventListener("click", () => {
+        const name = btn.dataset.panel;
+        const cls = `show-${name}`;
+        const wasOpen = document.body.classList.contains(cls);
+        // close any other open panel, then toggle this one
+        document.body.classList.remove("show-dose", "show-log", "show-actions");
+        document.querySelectorAll(".panel-tabs [data-panel]").forEach((b) => b.classList.remove("active"));
+        if (!wasOpen) {
+          document.body.classList.add(cls);
+          btn.classList.add("active");
+        }
+      });
+    });
 
     document.getElementById("helpBtn").addEventListener("click", () => this.toggleHelp());
     document.getElementById("endBtn").addEventListener("click", () => this.engine.cmdCallIt());


### PR DESCRIPTION
## Summary

Three improvements to the PALS Code Simulator (`code-simulator.*`), addressing a request for a **random patient selection**, a **mobile-accessible version**, and a **visual aesthetic upgrade**.

### 1. Random patient selection
- New **"🎲 Surprise me — random patient"** button on the setup screen.
- Picks a random scenario so learners can't pre-plan to a known rhythm/cause — closer to a real unannounced code. The chosen card briefly flashes before launching.

### 2. Mobile-accessible HUD
Previously the action rail was `display: none` on phones, removing every non-voice control. Now:
- The **dose card**, **code record**, and **action rail** become toggleable bottom sheets via a docked tab bar (💊 Doses / 📋 Record / ⚡ Actions), one open at a time so panels never overlap.
- Command bar reflows: talk button + tools on one row, text input full-width below; 16px input font to stop iOS zoom-on-focus.
- `env(safe-area-inset-*)` padding for notched devices; vital-monitor mirror kept (smaller); top-bar stats scroll horizontally.

### 3. Cel-shaded ("clinical illustration") visuals
Recommendation behind the change: for a sim about a child in cardiac arrest, photoreal realism is distressing/distracting and a childish cartoon trivializes it. A flat **medical-illustration register** keeps focus on the algorithm, makes the already-color-coded team roles pop, and lets skin-tone shifts read as a clinical signal.

- A single post-build `_toonify()` pass swaps realistic PBR materials (`MeshStandardMaterial`) for cel-shaded `MeshToonMaterial` with a hard tone ramp — geometry, role colors, and emissive cues preserved. Emissive/basic screens (monitor, defib, vent) are left untouched.
- This is also the **performance lever for mobile**: phones drop shadow maps, disable antialiasing, and cap pixel ratio (1.5×), with the flat shading carrying the look.

## Testing
- `node --check` passes on `code-simulator.js`.
- Static site (no build step). Recommend a quick manual smoke test in Chrome desktop + a phone/devtools mobile emulation to confirm the bottom sheets and cel shading render as intended.

## Notes / open questions
- The tone ramp (5 steps) is tuned for a soft, professional look rather than a harsh comic-book band — easy to dial up/down in `makeToonGradient()`.
- Could add a thin outline shell for a stronger illustrated edge later; left out to keep the diff low-risk and phone-friendly.

https://claude.ai/code/session_013cigCzqQRVZ7Zg3oPe9US1

---
_Generated by [Claude Code](https://claude.ai/code/session_013cigCzqQRVZ7Zg3oPe9US1)_